### PR TITLE
feat(#70): RFC 9651 Structured Field Values parser

### DIFF
--- a/src/_sf.ts
+++ b/src/_sf.ts
@@ -1,0 +1,256 @@
+/**
+ * RFC 9651 Structured Field Values parser. Internal use; not exported from
+ * the public surface yet. Used by Cache-Status (RFC 9211), Repr-Digest /
+ * Content-Digest (RFC 9530), and other SF-based headers.
+ *
+ * Implements parsers for the three top-level types: Item, List, Dictionary.
+ * Returns null on parse failure (no exceptions in the hot path).
+ */
+
+export type SfBareItem = number | string | boolean | { token: string } | Uint8Array
+export type SfParams = Record<string, SfBareItem>
+export type SfItem = { value: SfBareItem; params: SfParams }
+export type SfInnerList = { value: SfItem[]; params: SfParams }
+export type SfListMember = SfItem | SfInnerList
+export type SfDict = Record<string, SfItem | SfInnerList>
+
+class Cursor {
+  constructor(
+    public input: string,
+    public pos: number = 0,
+  ) {}
+  peek(): string {
+    return this.input[this.pos] ?? ""
+  }
+  consume(): string {
+    return this.input[this.pos++] ?? ""
+  }
+  eof(): boolean {
+    return this.pos >= this.input.length
+  }
+  skipSp(): void {
+    while (!this.eof() && this.input[this.pos] === " ") this.pos++
+  }
+  skipOws(): void {
+    while (!this.eof() && (this.input[this.pos] === " " || this.input[this.pos] === "\t"))
+      this.pos++
+  }
+}
+
+function isDigit(c: string): boolean {
+  return c >= "0" && c <= "9"
+}
+function isAlpha(c: string): boolean {
+  return (c >= "a" && c <= "z") || (c >= "A" && c <= "Z")
+}
+function isLcAlpha(c: string): boolean {
+  return c >= "a" && c <= "z"
+}
+function isTokenStart(c: string): boolean {
+  return isAlpha(c) || c === "*"
+}
+function isTokenChar(c: string): boolean {
+  return isAlpha(c) || isDigit(c) || "!#$%&'*+-.^_`|~:/".includes(c)
+}
+function isKeyStart(c: string): boolean {
+  return isLcAlpha(c) || c === "*"
+}
+function isKeyChar(c: string): boolean {
+  return isLcAlpha(c) || isDigit(c) || c === "_" || c === "-" || c === "." || c === "*"
+}
+
+function parseNumber(c: Cursor): number | null {
+  let sign = 1
+  if (c.peek() === "-") {
+    c.consume()
+    sign = -1
+  }
+  if (!isDigit(c.peek())) return null
+  let intPart = ""
+  while (!c.eof() && isDigit(c.peek())) intPart += c.consume()
+  if (intPart.length === 0) return null
+  if (c.peek() !== ".") {
+    if (intPart.length > 15) return null
+    return sign * Number(intPart)
+  }
+  // decimal
+  if (intPart.length > 12) return null
+  c.consume() // .
+  let frac = ""
+  while (!c.eof() && isDigit(c.peek())) frac += c.consume()
+  if (frac.length === 0 || frac.length > 3) return null
+  return sign * Number(intPart + "." + frac)
+}
+
+function parseString(c: Cursor): string | null {
+  if (c.consume() !== '"') return null
+  let out = ""
+  while (!c.eof()) {
+    const ch = c.consume()
+    if (ch === "\\") {
+      const next = c.consume()
+      if (next !== '"' && next !== "\\") return null
+      out += next
+    } else if (ch === '"') {
+      return out
+    } else {
+      const code = ch.charCodeAt(0)
+      if (code < 0x20 || code >= 0x7f) return null
+      out += ch
+    }
+  }
+  return null
+}
+
+function parseToken(c: Cursor): { token: string } | null {
+  if (!isTokenStart(c.peek())) return null
+  let s = c.consume()
+  while (!c.eof() && isTokenChar(c.peek())) s += c.consume()
+  return { token: s }
+}
+
+function parseByteSequence(c: Cursor): Uint8Array | null {
+  if (c.consume() !== ":") return null
+  let b64 = ""
+  while (!c.eof() && c.peek() !== ":") b64 += c.consume()
+  if (c.consume() !== ":") return null
+  try {
+    const bin = atob(b64)
+    const u8 = new Uint8Array(bin.length)
+    for (let i = 0; i < bin.length; i++) u8[i] = bin.charCodeAt(i)
+    return u8
+  } catch {
+    return null
+  }
+}
+
+function parseBoolean(c: Cursor): boolean | null {
+  if (c.consume() !== "?") return null
+  const ch = c.consume()
+  if (ch === "1") return true
+  if (ch === "0") return false
+  return null
+}
+
+function parseBareItem(c: Cursor): SfBareItem | null {
+  const ch = c.peek()
+  if (ch === "-" || isDigit(ch)) return parseNumber(c)
+  if (ch === '"') return parseString(c)
+  if (ch === ":") return parseByteSequence(c)
+  if (ch === "?") return parseBoolean(c)
+  if (isTokenStart(ch)) return parseToken(c)
+  return null
+}
+
+function parseKey(c: Cursor): string | null {
+  if (!isKeyStart(c.peek())) return null
+  let s = c.consume()
+  while (!c.eof() && isKeyChar(c.peek())) s += c.consume()
+  return s
+}
+
+function parseParameters(c: Cursor): SfParams | null {
+  const params: SfParams = {}
+  while (!c.eof() && c.peek() === ";") {
+    c.consume()
+    c.skipSp()
+    const key = parseKey(c)
+    if (key === null) return null
+    let value: SfBareItem = true
+    if (c.peek() === "=") {
+      c.consume()
+      const v = parseBareItem(c)
+      if (v === null) return null
+      value = v
+    }
+    params[key] = value
+  }
+  return params
+}
+
+function parseItemMember(c: Cursor): SfItem | null {
+  const value = parseBareItem(c)
+  if (value === null) return null
+  const params = parseParameters(c)
+  if (params === null) return null
+  return { value, params }
+}
+
+function parseInnerList(c: Cursor): SfInnerList | null {
+  if (c.consume() !== "(") return null
+  const items: SfItem[] = []
+  while (!c.eof()) {
+    c.skipSp()
+    if (c.peek() === ")") {
+      c.consume()
+      const params = parseParameters(c)
+      if (params === null) return null
+      return { value: items, params }
+    }
+    const item = parseItemMember(c)
+    if (item === null) return null
+    items.push(item)
+    if (c.peek() !== " " && c.peek() !== ")") return null
+  }
+  return null
+}
+
+function parseListMember(c: Cursor): SfListMember | null {
+  if (c.peek() === "(") return parseInnerList(c)
+  return parseItemMember(c)
+}
+
+export function parseSfItem(input: string): SfItem | null {
+  const c = new Cursor(input)
+  c.skipSp()
+  const item = parseItemMember(c)
+  if (item === null) return null
+  c.skipSp()
+  if (!c.eof()) return null
+  return item
+}
+
+export function parseSfList(input: string): SfListMember[] | null {
+  const c = new Cursor(input)
+  c.skipSp()
+  if (c.eof()) return []
+  const out: SfListMember[] = []
+  for (;;) {
+    const m = parseListMember(c)
+    if (m === null) return null
+    out.push(m)
+    c.skipOws()
+    if (c.eof()) return out
+    if (c.consume() !== ",") return null
+    c.skipOws()
+    if (c.eof()) return null // trailing comma
+  }
+}
+
+export function parseSfDict(input: string): SfDict | null {
+  const c = new Cursor(input)
+  c.skipSp()
+  if (c.eof()) return {}
+  const out: SfDict = {}
+  for (;;) {
+    const key = parseKey(c)
+    if (key === null) return null
+    let member: SfItem | SfInnerList
+    if (c.peek() === "=") {
+      c.consume()
+      const m = parseListMember(c)
+      if (m === null) return null
+      member = m
+    } else {
+      const params = parseParameters(c)
+      if (params === null) return null
+      member = { value: true, params }
+    }
+    out[key] = member
+    c.skipOws()
+    if (c.eof()) return out
+    if (c.consume() !== ",") return null
+    c.skipOws()
+    if (c.eof()) return null
+  }
+}

--- a/test/sf-parser.test.ts
+++ b/test/sf-parser.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest"
+import { parseSfDict, parseSfItem, parseSfList } from "../src/_sf.ts"
+
+describe("RFC 9651 SF parser — items", () => {
+  it("parses bare integer", () => {
+    expect(parseSfItem("42")).toEqual({ value: 42, params: {} })
+    expect(parseSfItem("-17")).toEqual({ value: -17, params: {} })
+  })
+
+  it("parses bare decimal", () => {
+    expect(parseSfItem("3.14")).toEqual({ value: 3.14, params: {} })
+    expect(parseSfItem("-0.5")).toEqual({ value: -0.5, params: {} })
+  })
+
+  it("parses string", () => {
+    expect(parseSfItem('"hello"')).toEqual({ value: "hello", params: {} })
+    expect(parseSfItem('"with \\"quote"')).toEqual({ value: 'with "quote', params: {} })
+  })
+
+  it("parses token", () => {
+    expect(parseSfItem("foo")).toEqual({ value: { token: "foo" }, params: {} })
+    expect(parseSfItem("text/plain")).toEqual({ value: { token: "text/plain" }, params: {} })
+  })
+
+  it("parses boolean", () => {
+    expect(parseSfItem("?1")).toEqual({ value: true, params: {} })
+    expect(parseSfItem("?0")).toEqual({ value: false, params: {} })
+  })
+
+  it("parses byte sequence", () => {
+    const r = parseSfItem(":aGVsbG8=:")
+    expect(r).not.toBeNull()
+    expect(r!.value).toBeInstanceOf(Uint8Array)
+    expect(new TextDecoder().decode(r!.value as Uint8Array)).toBe("hello")
+  })
+
+  it("parses parameters", () => {
+    expect(parseSfItem("42;foo=bar;baz")).toEqual({
+      value: 42,
+      params: { foo: { token: "bar" }, baz: true },
+    })
+  })
+
+  it("returns null on garbage", () => {
+    expect(parseSfItem("")).toBeNull()
+    expect(parseSfItem("???")).toBeNull()
+  })
+})
+
+describe("RFC 9651 SF parser — lists", () => {
+  it("parses simple list", () => {
+    const r = parseSfList("1, 2, 3")
+    expect(r).toEqual([
+      { value: 1, params: {} },
+      { value: 2, params: {} },
+      { value: 3, params: {} },
+    ])
+  })
+
+  it("parses list with parameters", () => {
+    const r = parseSfList("foo;a=1, bar;b=2")
+    expect(r).toEqual([
+      { value: { token: "foo" }, params: { a: 1 } },
+      { value: { token: "bar" }, params: { b: 2 } },
+    ])
+  })
+
+  it("parses inner list", () => {
+    const r = parseSfList('("a" "b");q=0.5, "c"')
+    expect(r).toEqual([
+      {
+        value: [
+          { value: "a", params: {} },
+          { value: "b", params: {} },
+        ],
+        params: { q: 0.5 },
+      },
+      { value: "c", params: {} },
+    ])
+  })
+
+  it("returns empty array on empty input", () => {
+    expect(parseSfList("")).toEqual([])
+    expect(parseSfList("   ")).toEqual([])
+  })
+
+  it("returns null on garbage", () => {
+    expect(parseSfList("???")).toBeNull()
+  })
+})
+
+describe("RFC 9651 SF parser — dictionaries", () => {
+  it("parses simple dict", () => {
+    const r = parseSfDict("a=1, b=2")
+    expect(r).toEqual({
+      a: { value: 1, params: {} },
+      b: { value: 2, params: {} },
+    })
+  })
+
+  it("parses bare keys (boolean true)", () => {
+    const r = parseSfDict("a, b=2, c")
+    expect(r).toEqual({
+      a: { value: true, params: {} },
+      b: { value: 2, params: {} },
+      c: { value: true, params: {} },
+    })
+  })
+
+  it("parses dict with parameters", () => {
+    const r = parseSfDict('hit;ttl=300, fwd="miss"')
+    expect(r).toEqual({
+      hit: { value: true, params: { ttl: 300 } },
+      fwd: { value: "miss", params: {} },
+    })
+  })
+
+  it("later duplicate key wins", () => {
+    const r = parseSfDict("a=1, a=2")
+    expect(r).toEqual({ a: { value: 2, params: {} } })
+  })
+
+  it("returns null on garbage", () => {
+    expect(parseSfDict("?garbage")).toBeNull()
+  })
+})
+
+describe("RFC 9651 SF parser — Cache-Status (RFC 9211) example", () => {
+  it("parses real-world Cache-Status header", () => {
+    const r = parseSfList(`ExampleCache; hit, ExampleCDN; fwd=miss; ttl=300`)
+    expect(r).toEqual([
+      { value: { token: "ExampleCache" }, params: { hit: true } },
+      { value: { token: "ExampleCDN" }, params: { fwd: { token: "miss" }, ttl: 300 } },
+    ])
+  })
+})


### PR DESCRIPTION
Closes #70.

Internal helper for SF-based headers. Three top-level parsers:
- `parseSfItem` (bare item + parameters)
- `parseSfList` (list of items / inner lists)
- `parseSfDict` (key/value with bare-key boolean shorthand)

Supports all 6 bare-item types: integer, decimal, string, token,
byte-sequence (base64), boolean. Parameters with bare-key true.
Returns null on parse failure (no exceptions in hot path).

## Why now

This is the **prerequisite** for several follow-ups in the post-audit roadmap (#103):
- #62 RateLimit-* parser (IETF draft uses SF-Dictionary)
- #69 RFC 9211 Cache-Status parser
- #76 RFC 9530 Repr-Digest / Content-Digest
- #71 Server-Timing (close to SF; reuses tokenizer ideas)

Shipping it first keeps every downstream issue smaller.

## Surface

Internal-only — not exported from the public surface. May later be exposed at \`misina/sf\` if user demand surfaces.

## Tests

19 new tests covering RFC 9651 examples + a real-world Cache-Status fixture. Total: 481 → 500 (+19).

## Bundle

Zero impact on core (internal helper, tree-shaken when unused).