### PR TITLE
chore: phase-1 security hardening (#51 #52 #53 #54)

### DIFF
--- a/src/_redirect.ts
+++ b/src/_redirect.ts
@@ -4,7 +4,14 @@ const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308])
 
 const DEFAULT_SAFE_HEADERS = ["accept", "accept-encoding", "accept-language", "user-agent"]
 
-const SENSITIVE_HEADERS = ["authorization", "cookie", "proxy-authorization", "www-authenticate"]
+const SENSITIVE_HEADERS = [
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+  "www-authenticate",
+  "signature",
+  "signature-input",
+]
 
 /**
  * Walk the driver through redirects manually so we can apply our header
@@ -68,6 +75,7 @@ export async function followRedirects(
       Object.fromEntries(current.headers),
       sameOrigin,
       options.redirectSafeHeaders,
+      options.redirectStripHeaders,
     )
 
     const downgrade = shouldDowngradeToGet(response.status, current.method)
@@ -147,13 +155,29 @@ function filterRedirectHeaders(
   headers: Record<string, string>,
   sameOrigin: boolean,
   safeList: string[] | undefined,
+  extraStrip: string[] | undefined,
 ): Record<string, string> {
-  if (sameOrigin) return headers
+  const stripSet = new Set(SENSITIVE_HEADERS)
+  if (extraStrip) for (const h of extraStrip) stripSet.add(h.toLowerCase())
+  if (sameOrigin) {
+    if (stripSet.size === SENSITIVE_HEADERS.length && !extraStrip) return headers
+    // Same-origin: keep everything except the explicit strip list. Built-in
+    // sensitive headers stay (same-origin can carry Authorization safely);
+    // user-supplied extras are still stripped, since they likely target a
+    // service-token leak that defense-in-depth wants gone everywhere.
+    if (!extraStrip) return headers
+    const out: Record<string, string> = {}
+    const extraStripLower = new Set(extraStrip.map((h) => h.toLowerCase()))
+    for (const [k, v] of Object.entries(headers)) {
+      if (!extraStripLower.has(k.toLowerCase())) out[k] = v
+    }
+    return out
+  }
   const safe = new Set((safeList ?? DEFAULT_SAFE_HEADERS).map((h) => h.toLowerCase()))
   const out: Record<string, string> = {}
   for (const [k, v] of Object.entries(headers)) {
     const lower = k.toLowerCase()
-    if (SENSITIVE_HEADERS.includes(lower)) continue
+    if (stripSet.has(lower)) continue
     if (safe.has(lower)) out[k] = v
   }
   return out

--- a/src/_url.ts
+++ b/src/_url.ts
@@ -24,13 +24,16 @@ export function resolveUrl(
   assertNoControlChars(input, "input")
   if (baseURL !== undefined) assertNoControlChars(baseURL, "baseURL")
   let resolved: string
+  const schemeRelative = input.startsWith("//")
   if (isAbsoluteUrl(input)) {
     if (!allowAbsoluteUrls && baseURL) {
       throw new Error(
         `misina: absolute URL ${JSON.stringify(input)} rejected because allowAbsoluteUrls is false`,
       )
     }
-    resolved = input
+    // Scheme-relative URLs need a base scheme to parse — resolve against
+    // baseURL when present, otherwise leave as-is for the driver.
+    resolved = schemeRelative && baseURL ? new URL(input, baseURL).toString() : input
   } else if (!baseURL) {
     resolved = input
   } else {
@@ -82,6 +85,9 @@ function assertAllowedProtocol(url: string, allowed: readonly string[]): void {
 }
 
 function isAbsoluteUrl(input: string): boolean {
+  // Scheme-relative URLs ('//host/path') resolve against the base scheme but
+  // change origin — treat them as absolute for the allowAbsoluteUrls gate.
+  if (input.startsWith("//")) return true
   return /^[a-z][a-z0-9+.-]*:/i.test(input)
 }
 

--- a/src/_url.ts
+++ b/src/_url.ts
@@ -21,6 +21,8 @@ export function resolveUrl(
   allowedProtocols: readonly string[] = ["http", "https"],
   trailingSlash: TrailingSlashPolicy = "preserve",
 ): string {
+  assertNoControlChars(input, "input")
+  if (baseURL !== undefined) assertNoControlChars(baseURL, "baseURL")
   let resolved: string
   if (isAbsoluteUrl(input)) {
     if (!allowAbsoluteUrls && baseURL) {
@@ -81,6 +83,18 @@ function assertAllowedProtocol(url: string, allowed: readonly string[]): void {
 
 function isAbsoluteUrl(input: string): boolean {
   return /^[a-z][a-z0-9+.-]*:/i.test(input)
+}
+
+function assertNoControlChars(value: string, label: string): void {
+  // CR/LF/NUL in a URL composition is request-smuggling territory. WHATWG
+  // URL parser tolerates some of these silently — explicit reject keeps
+  // the wire format honest. ofetch hit this in unjs/ofetch#530.
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i)
+    if (code === 0x00 || code === 0x0a || code === 0x0d) {
+      throw new Error(`misina: ${label} contains CR/LF/NUL (offset ${i})`)
+    }
+  }
 }
 
 function ensureTrailingSlash(url: string): string {

--- a/src/misina.ts
+++ b/src/misina.ts
@@ -470,6 +470,7 @@ function resolveOptions(
     next: init.next ?? defaults.next,
     redirect: init.redirect ?? defaults.redirect ?? "manual",
     redirectSafeHeaders: init.redirectSafeHeaders ?? defaults.redirectSafeHeaders,
+    redirectStripHeaders: init.redirectStripHeaders ?? defaults.redirectStripHeaders,
     redirectMaxCount: init.redirectMaxCount ?? defaults.redirectMaxCount ?? 5,
     redirectAllowDowngrade: init.redirectAllowDowngrade ?? defaults.redirectAllowDowngrade ?? false,
     throwHttpErrors: init.throwHttpErrors ?? defaults.throwHttpErrors ?? true,

--- a/src/typed.ts
+++ b/src/typed.ts
@@ -126,15 +126,37 @@ function substitutePathParams(path: string, params: Record<string, string | numb
       if (value == null) {
         throw new Error(`misina: missing path param :${key} for ${path}`)
       }
-      return encodeURIComponent(String(value))
+      return safePathParam(String(value), key, path)
     })
     .replace(/\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_, key: string) => {
       const value = params[key]
       if (value == null) {
         throw new Error(`misina: missing path param {${key}} for ${path}`)
       }
-      return encodeURIComponent(String(value))
+      return safePathParam(String(value), key, path)
     })
+}
+
+function safePathParam(value: string, key: string, path: string): string {
+  // Reject path traversal & separators. encodeURIComponent does encode `/`,
+  // `\`, `\0` — but `..` is literal-legal and would still be normalized by
+  // WHATWG URL into a parent segment. Reject the value early so the URL
+  // composition can't escape its template.
+  if (value === ".." || value === "." || value === "") {
+    throw new Error(
+      `misina: path param ${key} value ${JSON.stringify(value)} rejected (traversal) for ${path}`,
+    )
+  }
+  if (value.includes("/") || value.includes("\\") || value.includes("\0")) {
+    throw new Error(
+      `misina: path param ${key} contains separator (/, \\, NUL) — value ${JSON.stringify(value)} for ${path}`,
+    )
+  }
+  // CR/LF already caught upstream (#52); double-check at this layer.
+  if (value.includes("\r") || value.includes("\n")) {
+    throw new Error(`misina: path param ${key} contains CR/LF for ${path}`)
+  }
+  return encodeURIComponent(value)
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -254,6 +254,13 @@ export interface MisinaOptions {
   redirect?: "manual" | "follow" | "error"
   /** Allowlist of headers preserved on cross-origin redirects. Default: accept, accept-encoding, accept-language, user-agent. */
   redirectSafeHeaders?: string[]
+  /**
+   * Additional headers to strip on cross-origin redirects. Appended to the
+   * built-in list (`authorization`, `cookie`, `proxy-authorization`,
+   * `www-authenticate`, `signature`, `signature-input`). Use this for custom
+   * auth headers (`x-api-key`, `x-aws-token`, etc.).
+   */
+  redirectStripHeaders?: string[]
   /** Max redirects to follow before throwing. Default: 5. */
   redirectMaxCount?: number
   /** Allow https → http redirect. Default: false. */
@@ -396,6 +403,7 @@ export interface MisinaResolvedOptions {
   next: { revalidate?: number | false; tags?: string[] } | undefined
   redirect: "manual" | "follow" | "error"
   redirectSafeHeaders: string[] | undefined
+  redirectStripHeaders: string[] | undefined
   redirectMaxCount: number
   redirectAllowDowngrade: boolean
   throwHttpErrors: boolean

--- a/test/redirect-security.test.ts
+++ b/test/redirect-security.test.ts
@@ -221,4 +221,86 @@ describe("beforeRedirect hook — receives prepared next request", () => {
     await m.get("https://api.test/start")
     expect(seen[1]?.xtouched).toBe("yes")
   })
+
+  it("strips Signature + Signature-Input by default on cross-origin redirect", async () => {
+    const seen: { url: string; sig: string | null; sigIn: string | null }[] = []
+    const driver = {
+      name: "redirector",
+      request: async (req: Request) => {
+        seen.push({
+          url: req.url,
+          sig: req.headers.get("signature"),
+          sigIn: req.headers.get("signature-input"),
+        })
+        if (req.url === "https://api.example.com/start") {
+          return new Response(null, {
+            status: 302,
+            headers: { location: "https://other.example.com/dest" },
+          })
+        }
+        return jsonResponse({})
+      },
+    }
+    const m = createMisina({
+      driver,
+      retry: 0,
+      headers: { Signature: "sig=:abc:", "Signature-Input": "sig=();keyid=k1" },
+    })
+    await m.get("https://api.example.com/start")
+    expect(seen[0]?.sig).toBe("sig=:abc:")
+    expect(seen[1]?.sig).toBeNull()
+    expect(seen[1]?.sigIn).toBeNull()
+  })
+
+  it("strips user-supplied redirectStripHeaders on cross-origin redirect", async () => {
+    const seen: { url: string; apiKey: string | null }[] = []
+    const driver = {
+      name: "redirector",
+      request: async (req: Request) => {
+        seen.push({ url: req.url, apiKey: req.headers.get("x-api-key") })
+        if (req.url === "https://api.example.com/start") {
+          return new Response(null, {
+            status: 302,
+            headers: { location: "https://other.example.com/dest" },
+          })
+        }
+        return jsonResponse({})
+      },
+    }
+    const m = createMisina({
+      driver,
+      retry: 0,
+      headers: { "X-Api-Key": "secret-123" },
+      redirectStripHeaders: ["x-api-key"],
+    })
+    await m.get("https://api.example.com/start")
+    expect(seen[0]?.apiKey).toBe("secret-123")
+    expect(seen[1]?.apiKey).toBeNull()
+  })
+
+  it("redirectStripHeaders also applies to same-origin redirects", async () => {
+    const seen: { url: string; apiKey: string | null }[] = []
+    const driver = {
+      name: "redirector",
+      request: async (req: Request) => {
+        seen.push({ url: req.url, apiKey: req.headers.get("x-api-key") })
+        if (req.url === "https://api.example.com/start") {
+          return new Response(null, {
+            status: 302,
+            headers: { location: "https://api.example.com/dest" },
+          })
+        }
+        return jsonResponse({})
+      },
+    }
+    const m = createMisina({
+      driver,
+      retry: 0,
+      headers: { "X-Api-Key": "secret-123" },
+      redirectStripHeaders: ["x-api-key"],
+    })
+    await m.get("https://api.example.com/start")
+    expect(seen[0]?.apiKey).toBe("secret-123")
+    expect(seen[1]?.apiKey).toBeNull()
+  })
 })

--- a/test/typed-edges.test.ts
+++ b/test/typed-edges.test.ts
@@ -92,4 +92,47 @@ describe("createMisinaTyped — path param substitution edges", () => {
     await api.get("/search/:q", { params: { q: "hello world & more" } })
     expect(seen).toMatch(/hello%20world%20%26%20more/)
   })
+
+  it("rejects '..' as a path param value (traversal)", () => {
+    type Api2 = { "GET /users/:id": { params: { id: string }; response: unknown } }
+    const driver = {
+      name: "watch",
+      request: async () => jsonResponse({}),
+    }
+    const api = createMisinaTyped<Api2>({ driver, retry: 0, baseURL: "https://api.test" })
+    expect(() => api.get("/users/:id", { params: { id: ".." } })).toThrow(/traversal/)
+  })
+
+  it("rejects '/' separator in path param", () => {
+    type Api2 = { "GET /users/:id": { params: { id: string }; response: unknown } }
+    const driver = {
+      name: "watch",
+      request: async () => jsonResponse({}),
+    }
+    const api = createMisinaTyped<Api2>({ driver, retry: 0, baseURL: "https://api.test" })
+    expect(() => api.get("/users/:id", { params: { id: "../admin" } })).toThrow(/separator/)
+    expect(() => api.get("/users/:id", { params: { id: "a/b" } })).toThrow(/separator/)
+  })
+
+  it("rejects '\\\\' (backslash) and NUL in path param", () => {
+    type Api2 = { "GET /users/:id": { params: { id: string }; response: unknown } }
+    const driver = {
+      name: "watch",
+      request: async () => jsonResponse({}),
+    }
+    const api = createMisinaTyped<Api2>({ driver, retry: 0, baseURL: "https://api.test" })
+    expect(() => api.get("/users/:id", { params: { id: "a\\b" } })).toThrow(/separator/)
+    expect(() => api.get("/users/:id", { params: { id: "a\0b" } })).toThrow(/separator/)
+  })
+
+  it("rejects empty string and '.' segments", () => {
+    type Api2 = { "GET /users/:id": { params: { id: string }; response: unknown } }
+    const driver = {
+      name: "watch",
+      request: async () => jsonResponse({}),
+    }
+    const api = createMisinaTyped<Api2>({ driver, retry: 0, baseURL: "https://api.test" })
+    expect(() => api.get("/users/:id", { params: { id: "" } })).toThrow(/traversal/)
+    expect(() => api.get("/users/:id", { params: { id: "." } })).toThrow(/traversal/)
+  })
 })

--- a/test/url-control-chars.test.ts
+++ b/test/url-control-chars.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+import { createMisina } from "../src/index.ts"
+
+const noopDriver = {
+  name: "noop",
+  request: async () => new Response("{}", { headers: { "content-type": "application/json" } }),
+}
+
+describe("URL control-char guard", () => {
+  it("rejects \\r in baseURL", async () => {
+    const m = createMisina({ driver: noopDriver, baseURL: "https://api.example.com\r" })
+    await expect(m.get("/x")).rejects.toThrow(/CR\/LF\/NUL/)
+  })
+
+  it("rejects \\n in baseURL", async () => {
+    const m = createMisina({ driver: noopDriver, baseURL: "https://api.example.com\n" })
+    await expect(m.get("/x")).rejects.toThrow(/CR\/LF\/NUL/)
+  })
+
+  it("rejects \\0 in baseURL", async () => {
+    const m = createMisina({ driver: noopDriver, baseURL: "https://api.example.com\0" })
+    await expect(m.get("/x")).rejects.toThrow(/CR\/LF\/NUL/)
+  })
+
+  it("rejects \\r\\n in path", async () => {
+    const m = createMisina({ driver: noopDriver, baseURL: "https://api.example.com" })
+    await expect(m.get("/path\r\nwith-newline")).rejects.toThrow(/CR\/LF\/NUL/)
+  })
+
+  it("rejects \\0 in absolute URL input", async () => {
+    const m = createMisina({ driver: noopDriver })
+    await expect(m.get("https://api.example.com/x\0")).rejects.toThrow(/CR\/LF\/NUL/)
+  })
+
+  it("error mentions which side: baseURL or input", async () => {
+    const m = createMisina({ driver: noopDriver, baseURL: "https://x.com\r" })
+    await expect(m.get("/y")).rejects.toThrow(/baseURL/)
+
+    const m2 = createMisina({ driver: noopDriver, baseURL: "https://x.com" })
+    await expect(m2.get("/y\r")).rejects.toThrow(/input/)
+  })
+
+  it("permits normal URLs", async () => {
+    const m = createMisina({ driver: noopDriver, baseURL: "https://api.example.com" })
+    await expect(m.get("/users/42?q=hello")).resolves.toBeDefined()
+  })
+
+  it("permits %-encoded sequences (those are not raw CR/LF)", async () => {
+    const m = createMisina({ driver: noopDriver, baseURL: "https://api.example.com" })
+    await expect(m.get("/path%0A")).resolves.toBeDefined()
+  })
+})

--- a/test/url-ssrf-boundary.test.ts
+++ b/test/url-ssrf-boundary.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest"
+import { createMisina } from "../src/index.ts"
+
+const recordingDriver = (): {
+  name: string
+  request: (req: Request) => Promise<Response>
+  urls: string[]
+} => {
+  const urls: string[] = []
+  return {
+    name: "rec",
+    request: async (req) => {
+      urls.push(req.url)
+      return new Response("{}", { headers: { "content-type": "application/json" } })
+    },
+    urls,
+  }
+}
+
+describe("URL composition SSRF audit (ofetch#564)", () => {
+  it("path '.attacker.com/y' is appended INSIDE baseURL, not promoted to host", async () => {
+    const driver = recordingDriver()
+    const m = createMisina({ driver, retry: 0, baseURL: "https://api.internal" })
+    await m.get(".attacker.com/y")
+    // WHATWG URL resolves './.attacker.com/y' against
+    // 'https://api.internal/' → 'https://api.internal/.attacker.com/y'.
+    // Origin stays 'api.internal'.
+    expect(new URL(driver.urls[0]!).host).toBe("api.internal")
+    expect(driver.urls[0]).toBe("https://api.internal/.attacker.com/y")
+  })
+
+  it("absolute URL with allowAbsoluteUrls: false is rejected", async () => {
+    const driver = recordingDriver()
+    const m = createMisina({
+      driver,
+      retry: 0,
+      baseURL: "https://api.internal",
+      allowAbsoluteUrls: false,
+    })
+    await expect(m.get("https://attacker.com/y")).rejects.toThrow(/allowAbsoluteUrls/)
+  })
+
+  it("'..' segment in path stays inside baseURL origin (WHATWG normalization)", async () => {
+    const driver = recordingDriver()
+    const m = createMisina({ driver, retry: 0, baseURL: "https://api.internal/v1/" })
+    await m.get("../v2/users")
+    // WHATWG normalizes '..' but cannot escape the origin.
+    expect(new URL(driver.urls[0]!).host).toBe("api.internal")
+    expect(driver.urls[0]).toBe("https://api.internal/v2/users")
+  })
+
+  it("scheme-relative URL '//other.com/x' rejected with allowAbsoluteUrls: false", async () => {
+    const driver = recordingDriver()
+    const m = createMisina({
+      driver,
+      retry: 0,
+      baseURL: "https://api.internal",
+      allowAbsoluteUrls: false,
+    })
+    await expect(m.get("//other.com/x")).rejects.toThrow(/allowAbsoluteUrls/)
+  })
+
+  it("scheme-relative URL '//other.com/x' allowed by default (allowAbsoluteUrls: true)", async () => {
+    const driver = recordingDriver()
+    const m = createMisina({ driver, retry: 0, baseURL: "https://api.internal" })
+    const r = await m.get("//other.com/x")
+    expect(r.status).toBe(200)
+    expect(driver.urls[0]).toBe("https://other.com/x")
+  })
+
+  it("user@otherhost.com style URL is part of the path with baseURL set", async () => {
+    const driver = recordingDriver()
+    const m = createMisina({ driver, retry: 0, baseURL: "https://api.internal" })
+    // 'user@otherhost.com' is a relative path segment, not a userinfo.
+    await m.get("user@otherhost.com")
+    expect(new URL(driver.urls[0]!).host).toBe("api.internal")
+    expect(driver.urls[0]).toBe("https://api.internal/user@otherhost.com")
+  })
+
+  it("explicit absolute URL replaces baseURL when allowAbsoluteUrls: true (default)", async () => {
+    const driver = recordingDriver()
+    const m = createMisina({ driver, retry: 0, baseURL: "https://api.internal" })
+    await m.get("https://other.com/x")
+    expect(driver.urls[0]).toBe("https://other.com/x")
+  })
+})


### PR DESCRIPTION
Phase-1 security hardening from the post-audit roadmap (#103). Four small, independent commits — all defense-in-depth on the URL/redirect/path attack surface.

## Closes

- #51 redirectStripHeaders + Signature in default strip list
- #52 reject CR/LF/NUL in baseURL and path
- #53 scheme-relative URLs honor allowAbsoluteUrls + SSRF audit tests
- #54 reject path traversal in typed path params

## Summary

### #51 — Configurable redirect strip headers + RFC 9421 Signature
- New \`redirectStripHeaders: string[]\` option, appended to built-ins (\`authorization\`, \`cookie\`, \`proxy-authorization\`, \`www-authenticate\`).
- \`signature\` and \`signature-input\` (RFC 9421) added to the default strip list — message-signature auth would otherwise leak across cross-origin redirects (whatwg/fetch#1819).
- User-supplied entries also strip same-origin (defense in depth — typically service tokens).

### #52 — URL CR/LF/NUL guard
Header values were guarded; URL composition wasn't. WHATWG URL parser tolerates some of these silently — explicit reject keeps the wire format honest. ofetch#530.

### #53 — Scheme-relative URLs + SSRF audit
- \`isAbsoluteUrl\` now matches \`//host/path\` (these change origin and should be gated by \`allowAbsoluteUrls\`).
- Regression tests prove ofetch#564-style boundary bypass is structurally impossible (WHATWG URL, no string concat).

### #54 — Path traversal in typed params
\`createMisinaTyped\` substitution rejects \`..\`, \`.\`, empty segments, and segment separators (\`/\`, \`\\\`, NUL). \`encodeURIComponent\` doesn't encode \`..\` literally and WHATWG URL would still normalize it to a parent segment. openapi-typescript#2483.

## Tests

481 → 503 (+22 across 4 issues). All passing on Node 22.

## Bundle

No new public symbols other than \`redirectStripHeaders\` option. Existing options unchanged. Marginal size impact.