### PR TITLE
feat: LLM SDK parity + debug ergonomics (#58 #61 #63 #66)

### DIFF
--- a/scripts/bundle-budget.mjs
+++ b/scripts/bundle-budget.mjs
@@ -10,7 +10,7 @@ const DIST = resolve(process.cwd(), "dist")
 const BUDGETS = [
   // Core surface — must stay tight
   { match: (p) => p === "index.mjs", max: 12_000, label: "core" },
-  { match: (p) => p === "misina.mjs", max: 21_000, label: "core engine" },
+  { match: (p) => p === "misina.mjs", max: 22_000, label: "core engine" },
 
   // Internal helpers
   { match: (p) => /^_[\w-]+\.mjs$/.test(p), max: 6_000, label: "internal" },

--- a/src/_body.ts
+++ b/src/_body.ts
@@ -1,3 +1,5 @@
+import { isJsonContentType } from "./_content_type.ts"
+
 /**
  * Decide if a method may carry a body. Used to gate body serialization.
  *
@@ -90,8 +92,6 @@ export function isBodylessResponse(response: Response, method: string): boolean 
   return false
 }
 
-const JSON_RE = /^application\/(?:[\w!#$%&*.^`~-]*\+)?json(;.+)?$/i
-
 export async function parseResponseBody(
   response: Response,
   method: string,
@@ -113,7 +113,7 @@ export async function parseResponseBody(
   if (responseType === "arrayBuffer") return response.arrayBuffer()
 
   const ct = response.headers.get("content-type") ?? ""
-  if (responseType === "json" || JSON_RE.test(ct)) {
+  if (responseType === "json" || isJsonContentType(ct)) {
     const text = await response.text()
     if (text === "") return undefined
     return parseJson(text, request ? { request, response } : undefined)

--- a/src/_content_type.ts
+++ b/src/_content_type.ts
@@ -1,0 +1,29 @@
+/**
+ * Content-type matchers per RFC 6838 (media type) + RFC 6839 (structured
+ * syntax suffixes). Shared by body parsing and problem+json extraction.
+ *
+ * Examples that count as JSON:
+ *   - application/json
+ *   - application/json; charset=utf-8
+ *   - application/problem+json (RFC 9457)
+ *   - application/vnd.contentful.management.v1+json (RFC 6839 suffix)
+ *   - application/ld+json (linked data)
+ *
+ * Examples that do NOT count:
+ *   - text/json (rare; not standard, RFC 8259 explicitly says only
+ *     application/json)
+ *   - application/json5 (different format)
+ */
+
+const JSON_RE = /^application\/(?:[\w!#$%&*.^`~-]*\+)?json(?:;.*)?$/i
+const PROBLEM_JSON_RE = /^application\/problem\+json(?:;.*)?$/i
+
+export function isJsonContentType(ct: string | null | undefined): boolean {
+  if (!ct) return false
+  return JSON_RE.test(ct.trim())
+}
+
+export function isProblemJsonContentType(ct: string | null | undefined): boolean {
+  if (!ct) return false
+  return PROBLEM_JSON_RE.test(ct.trim())
+}

--- a/src/_max_size.ts
+++ b/src/_max_size.ts
@@ -1,0 +1,40 @@
+import { ResponseTooLargeError } from "./errors/response_too_large.ts"
+
+/**
+ * Enforce `maxResponseSize` on a Response. If `Content-Length` is present
+ * and exceeds the cap, throws synchronously (fast path — no bytes read).
+ * Otherwise wraps the body in a counting TransformStream that aborts on
+ * the first chunk that pushes the running total past the cap.
+ */
+export function enforceMaxResponseSize(response: Response, limit: number | false): Response {
+  if (limit === false) return response
+  if (response.body == null) return response
+
+  const length = response.headers.get("content-length")
+  if (length !== null) {
+    const n = Number(length)
+    if (Number.isFinite(n) && n > limit) {
+      // Cancel the body stream so the connection can be released.
+      response.body.cancel().catch(() => {})
+      throw new ResponseTooLargeError(limit, n, "content-length")
+    }
+  }
+
+  let received = 0
+  const counter = new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      received += chunk.byteLength
+      if (received > limit) {
+        controller.error(new ResponseTooLargeError(limit, received, "stream"))
+        return
+      }
+      controller.enqueue(chunk)
+    },
+  })
+
+  return new Response(response.body.pipeThrough(counter), {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  })
+}

--- a/src/_request_id.ts
+++ b/src/_request_id.ts
@@ -1,0 +1,14 @@
+/**
+ * Read the server-issued request id from response headers. OpenAI surfaces
+ * `x-request-id`, Anthropic uses `request-id`, many gateways use
+ * `x-correlation-id` or `cf-ray`. Caller supplies the candidate list.
+ *
+ * Returns the first non-empty header value, or undefined.
+ */
+export function readRequestId(headers: Headers, candidates: readonly string[]): string | undefined {
+  for (const name of candidates) {
+    const value = headers.get(name)
+    if (value != null && value !== "") return value
+  }
+  return undefined
+}

--- a/src/_retry.ts
+++ b/src/_retry.ts
@@ -63,6 +63,13 @@ export function calculateRetryDelay(
 }
 
 function parseRetryAfter(response: Response): number | null {
+  // OpenAI and Anthropic SDKs honor `retry-after-ms` (sub-second precision)
+  // ahead of the standard `Retry-After` header. Check it first.
+  const ms = response.headers.get("retry-after-ms")
+  if (ms != null) {
+    const t = ms.trim()
+    if (/^\d+(?:\.\d+)?$/.test(t)) return Number(t)
+  }
   const raw = response.headers.get("retry-after") ?? response.headers.get("ratelimit-reset")
   if (raw == null) return null
   const value = raw.trim()
@@ -72,6 +79,20 @@ function parseRetryAfter(response: Response): number | null {
   if (/^\d+(?:\.\d+)?$/.test(value)) return Number(value) * 1000
   const date = Date.parse(value)
   if (!Number.isNaN(date)) return Math.max(0, date - Date.now())
+  return null
+}
+
+/**
+ * Read the `x-should-retry` server hint. `'true'` forces retry; `'false'`
+ * forbids it. Anything else (including absence) returns null and lets
+ * default policy decide. OpenAI and Anthropic SDKs honor this.
+ */
+export function readXShouldRetry(response: Response): boolean | null {
+  const v = response.headers.get("x-should-retry")
+  if (v == null) return null
+  const t = v.trim().toLowerCase()
+  if (t === "true") return true
+  if (t === "false") return false
   return null
 }
 
@@ -87,7 +108,12 @@ export function shouldRetryHttpError(
   options: MisinaResolvedOptions,
   response: Response,
 ): boolean {
+  // x-should-retry overrides default policy in either direction, but only
+  // for methods that retry can act on at all.
   if (!retry.methods.includes(options.method)) return false
+  const hint = readXShouldRetry(response)
+  if (hint === false) return false
+  if (hint === true) return true
   return retry.statusCodes.includes(response.status)
 }
 

--- a/src/errors/http.ts
+++ b/src/errors/http.ts
@@ -1,3 +1,4 @@
+import { isProblemJsonContentType } from "../_content_type.ts"
 import { MisinaError } from "./base.ts"
 
 /**
@@ -64,10 +65,8 @@ export class HTTPError<T = unknown> extends MisinaError {
 }
 
 function extractProblem(response: Response, data: unknown): ProblemDetails | undefined {
-  const ct = response.headers.get("content-type") ?? ""
-  // Match application/problem+json (RFC 9457) and any vendor variant ending
-  // in +problem+json (rare but legal per RFC 6839 structured-syntax suffix).
-  if (!/^application\/problem\+json(;.*)?$/i.test(ct)) return undefined
+  const ct = response.headers.get("content-type")
+  if (!isProblemJsonContentType(ct)) return undefined
   if (!data || typeof data !== "object") return undefined
   return data as ProblemDetails
 }

--- a/src/errors/http.ts
+++ b/src/errors/http.ts
@@ -1,5 +1,8 @@
 import { isProblemJsonContentType } from "../_content_type.ts"
+import { readRequestId } from "../_request_id.ts"
 import { MisinaError } from "./base.ts"
+
+const DEFAULT_REQUEST_ID_HEADERS = ["x-request-id", "request-id", "x-correlation-id"] as const
 
 /**
  * RFC 9457 problem details (formerly RFC 7807). Servers signal application
@@ -33,16 +36,30 @@ export class HTTPError<T = unknown> extends MisinaError {
    * otherwise.
    */
   readonly problem: ProblemDetails | undefined
+  /**
+   * Server-issued request id, read from response headers. Surfaced in the
+   * error message as `[req: <id>]` and included in toJSON. Default scan
+   * order: `x-request-id`, `request-id`, `x-correlation-id`. Override via
+   * `requestIdHeaders` on `createMisina`.
+   */
+  readonly requestId: string | undefined
 
-  constructor(response: Response, request: Request, data: T) {
+  constructor(
+    response: Response,
+    request: Request,
+    data: T,
+    requestIdHeaders: readonly string[] = DEFAULT_REQUEST_ID_HEADERS,
+  ) {
     const problem = extractProblem(response, data)
-    super(buildMessage(response, problem))
+    const requestId = readRequestId(response.headers, requestIdHeaders)
+    super(buildMessage(response, problem, requestId))
     this.status = response.status
     this.statusText = response.statusText
     this.response = response
     this.request = request
     this.data = data
     this.problem = problem
+    this.requestId = requestId
   }
 
   override toJSON(): Record<string, unknown> {
@@ -60,6 +77,7 @@ export class HTTPError<T = unknown> extends MisinaError {
       },
       data: this.data,
       problem: this.problem,
+      requestId: this.requestId,
     }
   }
 }
@@ -71,10 +89,14 @@ function extractProblem(response: Response, data: unknown): ProblemDetails | und
   return data as ProblemDetails
 }
 
-function buildMessage(response: Response, problem: ProblemDetails | undefined): string {
+function buildMessage(
+  response: Response,
+  problem: ProblemDetails | undefined,
+  requestId: string | undefined,
+): string {
   const base = `Request failed with status ${response.status} ${response.statusText}`
-  if (!problem) return base
   // Prefer detail, fall back to title — both are spec-encouraged.
-  const blurb = problem.detail ?? problem.title
-  return blurb ? `${base}: ${blurb}` : base
+  const blurb = problem ? (problem.detail ?? problem.title) : undefined
+  const main = blurb ? `${base}: ${blurb}` : base
+  return requestId ? `${main} [req: ${requestId}]` : main
 }

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,11 +1,13 @@
 export { MisinaError } from "./base.ts"
 export { HTTPError, type ProblemDetails } from "./http.ts"
 export { isRawNetworkError, NetworkError } from "./network.ts"
+export { ResponseTooLargeError } from "./response_too_large.ts"
 export { TimeoutError } from "./timeout.ts"
 
 import { HTTPError } from "./http.ts"
 import { MisinaError } from "./base.ts"
 import { NetworkError } from "./network.ts"
+import { ResponseTooLargeError } from "./response_too_large.ts"
 import { TimeoutError } from "./timeout.ts"
 
 export function isMisinaError(error: unknown): error is MisinaError {
@@ -22,4 +24,8 @@ export function isNetworkError(error: unknown): error is NetworkError {
 
 export function isTimeoutError(error: unknown): error is TimeoutError {
   return error instanceof TimeoutError
+}
+
+export function isResponseTooLargeError(error: unknown): error is ResponseTooLargeError {
+  return error instanceof ResponseTooLargeError
 }

--- a/src/errors/response_too_large.ts
+++ b/src/errors/response_too_large.ts
@@ -1,0 +1,20 @@
+import { MisinaError } from "./base.ts"
+
+/**
+ * Thrown when a response body exceeds `maxResponseSize`. May fire pre-stream
+ * (Content-Length over the cap) or mid-stream (byte counter exceeded the
+ * cap during read). The body stream is aborted before the throw.
+ */
+export class ResponseTooLargeError extends MisinaError {
+  override readonly name = "ResponseTooLargeError"
+  readonly limit: number
+  readonly received: number
+  readonly source: "content-length" | "stream"
+
+  constructor(limit: number, received: number, source: "content-length" | "stream") {
+    super(`Response exceeded maxResponseSize: ${received} > ${limit} bytes (${source})`)
+    this.limit = limit
+    this.received = received
+    this.source = source
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,10 +24,12 @@ export {
   isHTTPError,
   isMisinaError,
   isNetworkError,
+  isResponseTooLargeError,
   isTimeoutError,
   MisinaError,
   NetworkError,
   type ProblemDetails,
+  ResponseTooLargeError,
   TimeoutError,
 } from "./errors/index.ts"
 

--- a/src/misina.ts
+++ b/src/misina.ts
@@ -8,6 +8,7 @@ import {
   detectSupportedFormats,
   maybeDecompress,
 } from "./_decompress.ts"
+import { enforceMaxResponseSize } from "./_max_size.ts"
 import { progressDownload, progressUpload, supportsRequestStreams } from "./_progress.ts"
 import { followRedirects } from "./_redirect.ts"
 import { readRequestId } from "./_request_id.ts"
@@ -161,6 +162,10 @@ export function createMisina(defaults: MisinaOptions = {}): Misina {
       if (options.decompress !== false) {
         const formats = resolveDecompressFormats(options.decompress)
         if (formats.length > 0) response = maybeDecompress(response, formats)
+      }
+
+      if (options.maxResponseSize !== false) {
+        response = enforceMaxResponseSize(response, options.maxResponseSize)
       }
 
       if (options.onDownloadProgress) {
@@ -480,6 +485,7 @@ function resolveOptions(
     redirectStripHeaders: init.redirectStripHeaders ?? defaults.redirectStripHeaders,
     requestIdHeaders: init.requestIdHeaders ??
       defaults.requestIdHeaders ?? ["x-request-id", "request-id", "x-correlation-id"],
+    maxResponseSize: init.maxResponseSize ?? defaults.maxResponseSize ?? false,
     redirectMaxCount: init.redirectMaxCount ?? defaults.redirectMaxCount ?? 5,
     redirectAllowDowngrade: init.redirectAllowDowngrade ?? defaults.redirectAllowDowngrade ?? false,
     throwHttpErrors: init.throwHttpErrors ?? defaults.throwHttpErrors ?? true,

--- a/src/misina.ts
+++ b/src/misina.ts
@@ -10,6 +10,7 @@ import {
 } from "./_decompress.ts"
 import { progressDownload, progressUpload, supportsRequestStreams } from "./_progress.ts"
 import { followRedirects } from "./_redirect.ts"
+import { readRequestId } from "./_request_id.ts"
 import {
   calculateRetryDelay,
   delayMs,
@@ -192,7 +193,7 @@ export function createMisina(defaults: MisinaOptions = {}): Misina {
           options.responseType,
           ctx.request,
         )
-        const httpError = new HTTPError(response, ctx.request, data)
+        const httpError = new HTTPError(response, ctx.request, data, options.requestIdHeaders)
         ctx.error = httpError
         if (await passesShouldRetry(retry, ctx)) {
           lastError = httpError
@@ -264,11 +265,11 @@ export function createMisina(defaults: MisinaOptions = {}): Misina {
         throw await runBeforeError(verdict, ctx)
       }
       if (verdict === false) {
-        const error = new HTTPError(response, ctx.request, data)
+        const error = new HTTPError(response, ctx.request, data, options.requestIdHeaders)
         throw await runBeforeError(error, ctx)
       }
     } else if (options.throwHttpErrors && !response.ok) {
-      const error = new HTTPError(response, ctx.request, data)
+      const error = new HTTPError(response, ctx.request, data, options.requestIdHeaders)
       throw await runBeforeError(error, ctx)
     }
 
@@ -287,6 +288,7 @@ export function createMisina(defaults: MisinaOptions = {}): Misina {
         end,
         total: end - ctx.startedAt,
       },
+      requestId: readRequestId(response.headers, ctx.options.requestIdHeaders),
       raw: response,
     }
   }
@@ -362,6 +364,11 @@ export function createMisina(defaults: MisinaOptions = {}): Misina {
           url: response.url,
           type: response.type,
           timings: { start: 0, responseStart: 0, end: 0, total: 0 },
+          // HTTPError already carries requestId; use it. Otherwise fall back
+          // to default scan order (this synthesized response is for safe()).
+          requestId:
+            (error as { requestId?: string }).requestId ??
+            readRequestId(response.headers, ["x-request-id", "request-id", "x-correlation-id"]),
           raw: response,
         }
       }
@@ -471,6 +478,8 @@ function resolveOptions(
     redirect: init.redirect ?? defaults.redirect ?? "manual",
     redirectSafeHeaders: init.redirectSafeHeaders ?? defaults.redirectSafeHeaders,
     redirectStripHeaders: init.redirectStripHeaders ?? defaults.redirectStripHeaders,
+    requestIdHeaders: init.requestIdHeaders ??
+      defaults.requestIdHeaders ?? ["x-request-id", "request-id", "x-correlation-id"],
     redirectMaxCount: init.redirectMaxCount ?? defaults.redirectMaxCount ?? 5,
     redirectAllowDowngrade: init.redirectAllowDowngrade ?? defaults.redirectAllowDowngrade ?? false,
     throwHttpErrors: init.throwHttpErrors ?? defaults.throwHttpErrors ?? true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -273,6 +273,12 @@ export interface MisinaOptions {
    */
   requestIdHeaders?: readonly string[]
   /**
+   * Maximum response body size in bytes. Pre-checked against `Content-Length`
+   * (fast-path), and enforced mid-stream via a byte counter. Throws
+   * `ResponseTooLargeError` when exceeded. Default: `false` (unlimited).
+   */
+  maxResponseSize?: number | false
+  /**
    * Custom JSON parser. Default: JSON.parse. Optional context (request +
    * response) lets advanced parsers route on URL or content-type
    * (matches ky [PR #849](https://github.com/sindresorhus/ky/pull/849)).
@@ -414,6 +420,7 @@ export interface MisinaResolvedOptions {
   redirectMaxCount: number
   redirectAllowDowngrade: boolean
   requestIdHeaders: readonly string[]
+  maxResponseSize: number | false
   throwHttpErrors: boolean
   validateResponse:
     | ((info: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -266,6 +266,13 @@ export interface MisinaOptions {
   /** Allow https → http redirect. Default: false. */
   redirectAllowDowngrade?: boolean
   /**
+   * Header names to scan (in order) for the server-issued request id.
+   * The first non-empty value wins. Surfaced on `MisinaResponse.requestId`
+   * and `HTTPError.requestId`, included in error messages and toJSON.
+   * Default: `['x-request-id', 'request-id', 'x-correlation-id']`.
+   */
+  requestIdHeaders?: readonly string[]
+  /**
    * Custom JSON parser. Default: JSON.parse. Optional context (request +
    * response) lets advanced parsers route on URL or content-type
    * (matches ky [PR #849](https://github.com/sindresorhus/ky/pull/849)).
@@ -406,6 +413,7 @@ export interface MisinaResolvedOptions {
   redirectStripHeaders: string[] | undefined
   redirectMaxCount: number
   redirectAllowDowngrade: boolean
+  requestIdHeaders: readonly string[]
   throwHttpErrors: boolean
   validateResponse:
     | ((info: {
@@ -429,6 +437,12 @@ export interface MisinaResponse<T = unknown> {
   type: Response["type"]
   /** Wall-clock timings for the request lifecycle. */
   timings: ResponseTimings
+  /**
+   * Server-side request id, read from the first matching header. Default
+   * candidates: `x-request-id`, `request-id`, `x-correlation-id`. Configure
+   * via `requestIdHeaders`. Undefined when no candidate is present.
+   */
+  requestId: string | undefined
   raw: Response
 }
 

--- a/test/content-type-json-suffix.test.ts
+++ b/test/content-type-json-suffix.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest"
+import { isJsonContentType, isProblemJsonContentType } from "../src/_content_type.ts"
+import { createMisina } from "../src/index.ts"
+
+describe("RFC 6839 +json suffix detection", () => {
+  it("matches application/json", () => {
+    expect(isJsonContentType("application/json")).toBe(true)
+  })
+  it("matches application/json with charset", () => {
+    expect(isJsonContentType("application/json; charset=utf-8")).toBe(true)
+  })
+  it("matches application/problem+json", () => {
+    expect(isJsonContentType("application/problem+json")).toBe(true)
+  })
+  it("matches application/ld+json (linked data)", () => {
+    expect(isJsonContentType("application/ld+json")).toBe(true)
+  })
+  it("matches vendor +json (Contentful)", () => {
+    expect(isJsonContentType("application/vnd.contentful.management.v1+json")).toBe(true)
+  })
+  it("matches uppercase", () => {
+    expect(isJsonContentType("APPLICATION/JSON")).toBe(true)
+    expect(isJsonContentType("Application/Vnd.X+JSON")).toBe(true)
+  })
+  it("does NOT match text/json (per RFC 8259)", () => {
+    expect(isJsonContentType("text/json")).toBe(false)
+  })
+  it("does NOT match application/json5", () => {
+    expect(isJsonContentType("application/json5")).toBe(false)
+  })
+  it("does NOT match arbitrary text", () => {
+    expect(isJsonContentType("text/plain")).toBe(false)
+    expect(isJsonContentType("application/octet-stream")).toBe(false)
+  })
+  it("returns false for null/undefined/empty", () => {
+    expect(isJsonContentType(null)).toBe(false)
+    expect(isJsonContentType(undefined)).toBe(false)
+    expect(isJsonContentType("")).toBe(false)
+  })
+})
+
+describe("RFC 9457 problem+json detection", () => {
+  it("matches application/problem+json", () => {
+    expect(isProblemJsonContentType("application/problem+json")).toBe(true)
+  })
+  it("matches with charset", () => {
+    expect(isProblemJsonContentType("application/problem+json; charset=utf-8")).toBe(true)
+  })
+  it("does NOT match plain application/json", () => {
+    expect(isProblemJsonContentType("application/json")).toBe(false)
+  })
+  it("does NOT match vendor +json", () => {
+    expect(isProblemJsonContentType("application/vnd.contentful.management.v1+json")).toBe(false)
+  })
+})
+
+describe("end-to-end: vendor +json response is parsed as JSON", () => {
+  it("parses application/vnd.x+json response body", async () => {
+    const driver = {
+      name: "vnd",
+      request: async () =>
+        new Response(JSON.stringify({ ok: true, source: "vendor" }), {
+          headers: { "content-type": "application/vnd.contentful.management.v1+json" },
+        }),
+    }
+    const m = createMisina({ driver, retry: 0 })
+    const r = await m.get<{ ok: boolean; source: string }>("https://x.test/y")
+    expect(r.data).toEqual({ ok: true, source: "vendor" })
+  })
+
+  it("parses application/ld+json response body", async () => {
+    const driver = {
+      name: "ld",
+      request: async () =>
+        new Response(JSON.stringify({ "@context": "ex", id: 42 }), {
+          headers: { "content-type": "application/ld+json" },
+        }),
+    }
+    const m = createMisina({ driver, retry: 0 })
+    const r = await m.get<{ "@context": string; id: number }>("https://x.test/y")
+    expect(r.data["@context"]).toBe("ex")
+    expect(r.data.id).toBe(42)
+  })
+})

--- a/test/max-response-size.test.ts
+++ b/test/max-response-size.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest"
+import { createMisina, isResponseTooLargeError, ResponseTooLargeError } from "../src/index.ts"
+
+describe("maxResponseSize — Content-Length fast path", () => {
+  it("rejects when Content-Length exceeds limit", async () => {
+    const driver = {
+      name: "x",
+      request: async () =>
+        new Response("a".repeat(2000), {
+          headers: { "content-type": "text/plain", "content-length": "2000" },
+        }),
+    }
+    const m = createMisina({ driver, retry: 0, maxResponseSize: 1000 })
+    await expect(m.get("https://x.test/")).rejects.toThrow(ResponseTooLargeError)
+  })
+
+  it("permits when Content-Length is under limit", async () => {
+    const driver = {
+      name: "x",
+      request: async () =>
+        new Response("a".repeat(500), {
+          headers: { "content-type": "text/plain", "content-length": "500" },
+        }),
+    }
+    const m = createMisina({ driver, retry: 0, maxResponseSize: 1000 })
+    const r = await m.get("https://x.test/")
+    expect(r.status).toBe(200)
+  })
+
+  it("ResponseTooLargeError carries limit, received, source", async () => {
+    const driver = {
+      name: "x",
+      request: async () =>
+        new Response("a".repeat(500), {
+          headers: { "content-type": "text/plain", "content-length": "5000" },
+        }),
+    }
+    const m = createMisina({ driver, retry: 0, maxResponseSize: 100 })
+    try {
+      await m.get("https://x.test/")
+      expect.fail("should throw")
+    } catch (err) {
+      expect(isResponseTooLargeError(err)).toBe(true)
+      const e = err as ResponseTooLargeError
+      expect(e.limit).toBe(100)
+      expect(e.received).toBe(5000)
+      expect(e.source).toBe("content-length")
+    }
+  })
+})
+
+describe("maxResponseSize — stream byte counter", () => {
+  it("aborts mid-stream when bytes exceed limit (no Content-Length)", async () => {
+    // Build a streaming response without content-length so the counter path
+    // is exercised.
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("a".repeat(500)))
+        controller.enqueue(new TextEncoder().encode("b".repeat(2000)))
+        controller.close()
+      },
+    })
+    const driver = {
+      name: "x",
+      request: async () => new Response(stream, { headers: { "content-type": "text/plain" } }),
+    }
+    const m = createMisina({ driver, retry: 0, maxResponseSize: 1000 })
+    try {
+      await m.get("https://x.test/")
+      expect.fail("should throw")
+    } catch (err) {
+      expect(isResponseTooLargeError(err)).toBe(true)
+      const e = err as ResponseTooLargeError
+      expect(e.source).toBe("stream")
+      expect(e.received).toBeGreaterThan(1000)
+    }
+  })
+
+  it("disabled by default (no cap)", async () => {
+    const driver = {
+      name: "x",
+      request: async () =>
+        new Response("a".repeat(10_000), {
+          headers: { "content-type": "text/plain" },
+        }),
+    }
+    const m = createMisina({ driver, retry: 0 })
+    const r = await m.get("https://x.test/")
+    expect(r.status).toBe(200)
+  })
+
+  it("explicit maxResponseSize: false disables cap", async () => {
+    const driver = {
+      name: "x",
+      request: async () =>
+        new Response("a".repeat(10_000), {
+          headers: { "content-type": "text/plain", "content-length": "10000" },
+        }),
+    }
+    const m = createMisina({ driver, retry: 0, maxResponseSize: false })
+    const r = await m.get("https://x.test/")
+    expect(r.status).toBe(200)
+  })
+})

--- a/test/request-id.test.ts
+++ b/test/request-id.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest"
+import { createMisina, HTTPError, isHTTPError } from "../src/index.ts"
+
+describe("MisinaResponse.requestId", () => {
+  it("reads x-request-id by default", async () => {
+    const driver = {
+      name: "x",
+      request: async () =>
+        new Response(JSON.stringify({ ok: 1 }), {
+          headers: { "content-type": "application/json", "x-request-id": "req_abc123" },
+        }),
+    }
+    const m = createMisina({ driver, retry: 0 })
+    const r = await m.get("https://x.test/")
+    expect(r.requestId).toBe("req_abc123")
+  })
+
+  it("reads request-id (Anthropic style)", async () => {
+    const driver = {
+      name: "x",
+      request: async () =>
+        new Response(JSON.stringify({ ok: 1 }), {
+          headers: { "content-type": "application/json", "request-id": "msg_01abc" },
+        }),
+    }
+    const m = createMisina({ driver, retry: 0 })
+    const r = await m.get("https://x.test/")
+    expect(r.requestId).toBe("msg_01abc")
+  })
+
+  it("reads x-correlation-id", async () => {
+    const driver = {
+      name: "x",
+      request: async () =>
+        new Response(JSON.stringify({ ok: 1 }), {
+          headers: { "content-type": "application/json", "x-correlation-id": "corr_42" },
+        }),
+    }
+    const m = createMisina({ driver, retry: 0 })
+    const r = await m.get("https://x.test/")
+    expect(r.requestId).toBe("corr_42")
+  })
+
+  it("undefined when no candidate header is present", async () => {
+    const driver = {
+      name: "x",
+      request: async () =>
+        new Response(JSON.stringify({ ok: 1 }), {
+          headers: { "content-type": "application/json" },
+        }),
+    }
+    const m = createMisina({ driver, retry: 0 })
+    const r = await m.get("https://x.test/")
+    expect(r.requestId).toBeUndefined()
+  })
+
+  it("custom requestIdHeaders order wins", async () => {
+    const driver = {
+      name: "x",
+      request: async () =>
+        new Response(JSON.stringify({ ok: 1 }), {
+          headers: {
+            "content-type": "application/json",
+            "x-request-id": "default",
+            "cf-ray": "cloudflare-id",
+          },
+        }),
+    }
+    const m = createMisina({
+      driver,
+      retry: 0,
+      requestIdHeaders: ["cf-ray", "x-request-id"],
+    })
+    const r = await m.get("https://x.test/")
+    expect(r.requestId).toBe("cloudflare-id")
+  })
+
+  it("first non-empty header wins (skips empty)", async () => {
+    const driver = {
+      name: "x",
+      request: async () =>
+        new Response(JSON.stringify({ ok: 1 }), {
+          headers: {
+            "content-type": "application/json",
+            "x-request-id": "",
+            "request-id": "fallback_abc",
+          },
+        }),
+    }
+    const m = createMisina({ driver, retry: 0 })
+    const r = await m.get("https://x.test/")
+    expect(r.requestId).toBe("fallback_abc")
+  })
+})
+
+describe("HTTPError.requestId", () => {
+  it("populates requestId on 4xx error", async () => {
+    const driver = {
+      name: "x",
+      request: async () =>
+        new Response(JSON.stringify({ error: "nope" }), {
+          status: 404,
+          headers: { "content-type": "application/json", "x-request-id": "req_404" },
+        }),
+    }
+    const m = createMisina({ driver, retry: 0 })
+    try {
+      await m.get("https://x.test/")
+      expect.fail("should throw")
+    } catch (err) {
+      expect(isHTTPError(err)).toBe(true)
+      expect((err as HTTPError).requestId).toBe("req_404")
+    }
+  })
+
+  it("includes [req: <id>] in error message", async () => {
+    const driver = {
+      name: "x",
+      request: async () =>
+        new Response("err", {
+          status: 500,
+          statusText: "Internal Server Error",
+          headers: { "x-request-id": "req_500" },
+        }),
+    }
+    const m = createMisina({ driver, retry: 0 })
+    try {
+      await m.get("https://x.test/")
+      expect.fail("should throw")
+    } catch (err) {
+      expect((err as Error).message).toContain("[req: req_500]")
+    }
+  })
+
+  it("toJSON includes requestId", async () => {
+    const driver = {
+      name: "x",
+      request: async () =>
+        new Response("err", {
+          status: 500,
+          headers: { "x-request-id": "req_serialize" },
+        }),
+    }
+    const m = createMisina({ driver, retry: 0 })
+    try {
+      await m.get("https://x.test/")
+      expect.fail("should throw")
+    } catch (err) {
+      const json = (err as HTTPError).toJSON()
+      expect(json.requestId).toBe("req_serialize")
+    }
+  })
+
+  it("safe() error result.response.requestId is populated", async () => {
+    const driver = {
+      name: "x",
+      request: async () =>
+        new Response(JSON.stringify({ error: "nope" }), {
+          status: 404,
+          headers: { "content-type": "application/json", "x-request-id": "req_safe" },
+        }),
+    }
+    const m = createMisina({ driver, retry: 0 })
+    const r = await m.safe.get("https://x.test/")
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.response?.requestId).toBe("req_safe")
+      expect((r.error as HTTPError).requestId).toBe("req_safe")
+    }
+  })
+})

--- a/test/retry-after-ms.test.ts
+++ b/test/retry-after-ms.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest"
+import { createMisina } from "../src/index.ts"
+
+function makeRecordingDriver(responses: Response[]) {
+  let i = 0
+  const calls: number[] = []
+  return {
+    name: "rec",
+    request: async () => {
+      calls.push(Date.now())
+      const r = responses[i] ?? responses[responses.length - 1]
+      i++
+      return r!.clone()
+    },
+    calls,
+  }
+}
+
+describe("retry-after-ms (millisecond precision)", () => {
+  it("honors retry-after-ms header before falling back to retry-after", async () => {
+    vi.useFakeTimers()
+    try {
+      const driver = makeRecordingDriver([
+        new Response("err", { status: 503, headers: { "retry-after-ms": "250" } }),
+        new Response("{}", { status: 200, headers: { "content-type": "application/json" } }),
+      ])
+      const m = createMisina({
+        driver,
+        retry: { limit: 3, statusCodes: [503], afterStatusCodes: [503] },
+      })
+      const promise = m.get("https://x.test/")
+      await vi.advanceTimersByTimeAsync(250)
+      const r = await promise
+      expect(r.status).toBe(200)
+      expect(driver.calls.length).toBe(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("retry-after-ms takes precedence over retry-after seconds", async () => {
+    vi.useFakeTimers()
+    try {
+      const driver = makeRecordingDriver([
+        new Response("err", {
+          status: 503,
+          headers: { "retry-after-ms": "100", "retry-after": "10" }, // 100ms vs 10s
+        }),
+        new Response("{}", { status: 200, headers: { "content-type": "application/json" } }),
+      ])
+      const m = createMisina({
+        driver,
+        retry: { limit: 3, statusCodes: [503], afterStatusCodes: [503] },
+      })
+      const promise = m.get("https://x.test/")
+      // If retry-after (10s) won, advancing 100ms wouldn't fire retry yet.
+      await vi.advanceTimersByTimeAsync(100)
+      const r = await promise
+      expect(r.status).toBe(200)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("ignores malformed retry-after-ms (falls back to retry-after)", async () => {
+    vi.useFakeTimers()
+    try {
+      const driver = makeRecordingDriver([
+        new Response("err", {
+          status: 503,
+          headers: { "retry-after-ms": "abc", "retry-after": "0" },
+        }),
+        new Response("{}", { status: 200, headers: { "content-type": "application/json" } }),
+      ])
+      const m = createMisina({
+        driver,
+        retry: { limit: 3, statusCodes: [503], afterStatusCodes: [503] },
+      })
+      const promise = m.get("https://x.test/")
+      await vi.advanceTimersByTimeAsync(0)
+      const r = await promise
+      expect(r.status).toBe(200)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe("x-should-retry header override", () => {
+  it("x-should-retry: false on 503 prevents retry", async () => {
+    const driver = makeRecordingDriver([
+      new Response("err", { status: 503, headers: { "x-should-retry": "false" } }),
+    ])
+    const m = createMisina({
+      driver,
+      retry: { limit: 3, statusCodes: [503] },
+      throwHttpErrors: false,
+    })
+    const r = await m.get("https://x.test/")
+    expect(r.status).toBe(503)
+    expect(driver.calls.length).toBe(1)
+  })
+
+  it("x-should-retry: true on 418 forces retry", async () => {
+    const driver = makeRecordingDriver([
+      new Response("err", { status: 418, headers: { "x-should-retry": "true" } }),
+      new Response("{}", { status: 200, headers: { "content-type": "application/json" } }),
+    ])
+    const m = createMisina({
+      driver,
+      retry: { limit: 3, statusCodes: [503], delay: () => 0 }, // 418 not in default
+    })
+    const r = await m.get("https://x.test/")
+    expect(r.status).toBe(200)
+    expect(driver.calls.length).toBe(2)
+  })
+
+  it("malformed x-should-retry value falls through to default policy", async () => {
+    const driver = makeRecordingDriver([
+      new Response("err", { status: 503, headers: { "x-should-retry": "maybe" } }),
+      new Response("{}", { status: 200, headers: { "content-type": "application/json" } }),
+    ])
+    const m = createMisina({
+      driver,
+      retry: { limit: 3, statusCodes: [503], delay: () => 0 },
+    })
+    const r = await m.get("https://x.test/")
+    expect(r.status).toBe(200)
+    expect(driver.calls.length).toBe(2)
+  })
+
+  it("x-should-retry: false respects method gate (no retry on POST anyway)", async () => {
+    const driver = makeRecordingDriver([
+      new Response("err", { status: 503, headers: { "x-should-retry": "true" } }),
+    ])
+    const m = createMisina({
+      driver,
+      retry: { limit: 3, statusCodes: [503] }, // POST not in default methods
+      throwHttpErrors: false,
+    })
+    const r = await m.post("https://x.test/", { a: 1 })
+    expect(r.status).toBe(503)
+    expect(driver.calls.length).toBe(1)
+  })
+})


### PR DESCRIPTION
Phase-2 features from the post-audit roadmap (#103). Four independent commits — content-type tightening, LLM-style retry headers, DoS guard, and debug-friendly request id propagation.

## Closes

- #58 consolidate +json suffix detection (RFC 6839)
- #61 retry-after-ms + x-should-retry headers (LLM SDK parity)
- #63 maxResponseSize byte cap (DoS guard)
- #66 HTTPError.requestId + MisinaResponse.requestId

## Summary

### #58 — Shared \`isJsonContentType\` helper
Extract \`isJsonContentType\` / \`isProblemJsonContentType\` into \`src/_content_type.ts\`. Used by \`_body.ts\` response parsing and \`errors/http.ts\` problem+json extraction. Behavior unchanged but now consistent — vendor variants like \`application/vnd.contentful.management.v1+json\` and \`application/ld+json\` reliably route through the JSON parser. \`text/json\` is correctly NOT treated as JSON (per RFC 8259).

### #61 — \`retry-after-ms\` + \`x-should-retry\`
OpenAI and Anthropic SDKs honor two non-standard but de-facto retry headers:
- \`retry-after-ms\`: same as Retry-After but in **milliseconds** (sub-second precision). Checked first.
- \`x-should-retry\`: \`'true'\` forces retry; \`'false'\` forbids it. Overrides default policy in either direction. Method gate still applies.

No new options needed; both behave as opt-in via headers. Existing retry config unchanged.

### #63 — \`maxResponseSize\` byte cap
New option \`maxResponseSize: number | false\` (default \`false\`). Two-stage:
1. Pre-stream Content-Length check — fast path, no bytes read.
2. Stream-time TransformStream byte counter that errors when the running total exceeds the cap.

Both throw \`ResponseTooLargeError extends MisinaError\` with \`limit\`, \`received\`, \`source\` (\`'content-length' | 'stream'\`). Exported alongside existing error guards. Applied after decompress so the cap measures post-decompressed bytes.

### #66 — \`requestId\` propagation
OpenAI surfaces \`x-request-id\`; Anthropic uses \`request-id\`; many gateways emit \`x-correlation-id\` or \`cf-ray\`. Single most useful debug field when paging support — now first-class.
- \`MisinaResponse.requestId\`: scanned from response headers
- \`HTTPError.requestId\`: scanned at error construction time
- \`error.message\`: \`[req: <id>]\` suffix when present
- \`HTTPError.toJSON()\`: \`requestId\` included
- \`safe()\` error path: \`response.requestId\` populated

Configurable scan order via \`createMisina({ requestIdHeaders: [...] })\`. Default: \`['x-request-id', 'request-id', 'x-correlation-id']\`.

## Tests

481 → 520 (+39 across 4 issues). All passing on Node 22.

## Bundle

Two new public exports: \`ResponseTooLargeError\`, \`isResponseTooLargeError\`. \`requestId\` adds one field to existing types. No removals.