### PR TITLE
feat(#62): misina/ratelimit — parseRateLimitHeaders helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,10 @@
     "./poll": {
       "types": "./dist/poll/index.d.mts",
       "default": "./dist/poll/index.mjs"
+    },
+    "./ratelimit": {
+      "types": "./dist/ratelimit/index.d.mts",
+      "default": "./dist/ratelimit/index.mjs"
     }
   },
   "publishConfig": {

--- a/scripts/bundle-budget.mjs
+++ b/scripts/bundle-budget.mjs
@@ -27,6 +27,7 @@ const BUDGETS = [
   { match: (p) => p.startsWith("test/"), max: 6_000, label: "test" },
   { match: (p) => p.startsWith("breaker/"), max: 4_000, label: "breaker" },
   { match: (p) => p.startsWith("poll/"), max: 2_500, label: "poll" },
+  { match: (p) => p.startsWith("ratelimit/"), max: 2_500, label: "ratelimit" },
   { match: (p) => p.startsWith("openapi/"), max: 200, label: "openapi (type-only)" },
   { match: (p) => p === "typed.mjs", max: 6_000, label: "typed" },
   { match: (p) => p === "types.mjs", max: 200, label: "types" },

--- a/src/ratelimit/index.ts
+++ b/src/ratelimit/index.ts
@@ -1,0 +1,118 @@
+/**
+ * Rate-limit header parser. Recognizes the de-facto OpenAI / Anthropic
+ * style (`x-ratelimit-*-requests` / `x-ratelimit-*-tokens`) and the IETF
+ * draft (`RateLimit-Limit` / `RateLimit-Remaining` / `RateLimit-Reset`).
+ * Returns null when no recognized headers are present.
+ *
+ * Reset values are normalized to a `Date`. The header may carry:
+ *   - ISO 8601 string  (`'2026-04-26T15:00:00Z'`)
+ *   - Unix seconds     (`'1745680800'` — large absolute, or small relative)
+ *   - duration suffix  (`'10s'`, `'500ms'`, `'1m30s'`)
+ *
+ * No core changes; pair with a token-bucket limiter (#92) or feed into
+ * `onComplete` for telemetry.
+ */
+
+export interface RateLimitBucket {
+  limit: number | undefined
+  remaining: number | undefined
+  resetAt: Date | undefined
+}
+
+export interface RateLimitInfo {
+  requests: RateLimitBucket | undefined
+  tokens: RateLimitBucket | undefined
+}
+
+export function parseRateLimitHeaders(headers: Headers): RateLimitInfo | null {
+  const requests = readBucket(headers, "requests")
+  const tokens = readBucket(headers, "tokens")
+  // IETF draft style has no -requests/-tokens suffix; fall back to that
+  // generic form when the OpenAI-style buckets are absent.
+  const generic = !requests && !tokens ? readBucket(headers, "") : undefined
+  if (!requests && !tokens && !generic) return null
+  return {
+    requests: requests ?? generic,
+    tokens,
+  }
+}
+
+function readBucket(
+  headers: Headers,
+  suffix: "requests" | "tokens" | "",
+): RateLimitBucket | undefined {
+  const sfx = suffix === "" ? "" : `-${suffix}`
+  // For named buckets ('requests'/'tokens'), only consider headers that
+  // actually carry the suffix. Falling through to the generic 'ratelimit-*'
+  // would let the same generic value be reported as both 'requests' and
+  // 'tokens' — the generic bucket is handled explicitly by parseRateLimitHeaders.
+  const limit = pickNumber(headers, [`x-ratelimit-limit${sfx}`, `ratelimit-limit${sfx}`])
+  const remaining = pickNumber(headers, [
+    `x-ratelimit-remaining${sfx}`,
+    `ratelimit-remaining${sfx}`,
+  ])
+  const resetAt = pickReset(headers, [`x-ratelimit-reset${sfx}`, `ratelimit-reset${sfx}`])
+  if (limit === undefined && remaining === undefined && resetAt === undefined) return undefined
+  return { limit, remaining, resetAt }
+}
+
+function pickNumber(headers: Headers, names: string[]): number | undefined {
+  for (const n of names) {
+    const v = headers.get(n)
+    if (v == null) continue
+    const num = Number(v.trim())
+    if (Number.isFinite(num)) return num
+  }
+  return undefined
+}
+
+function pickReset(headers: Headers, names: string[]): Date | undefined {
+  for (const n of names) {
+    const v = headers.get(n)
+    if (v == null) continue
+    const parsed = parseResetValue(v.trim())
+    if (parsed) return parsed
+  }
+  return undefined
+}
+
+function parseResetValue(value: string): Date | undefined {
+  if (value === "") return undefined
+  const dur = parseDuration(value)
+  if (dur !== undefined) return new Date(Date.now() + dur)
+  if (/^\d+$/.test(value)) {
+    const n = Number(value)
+    // Heuristic: very small numbers are seconds-from-now, larger are
+    // absolute Unix seconds. Threshold ~100k seconds (~28 hours).
+    if (n < 100_000) return new Date(Date.now() + n * 1000)
+    return new Date(n * 1000)
+  }
+  const ts = Date.parse(value)
+  if (!Number.isNaN(ts)) return new Date(ts)
+  return undefined
+}
+
+function parseDuration(value: string): number | undefined {
+  if (!/^(?:\d+(?:\.\d+)?(?:ms|s|m|h))+$/.test(value)) return undefined
+  let total = 0
+  const re = /(\d+(?:\.\d+)?)(ms|s|m|h)/g
+  let match: RegExpExecArray | null
+  while ((match = re.exec(value)) !== null) {
+    const n = Number(match[1])
+    switch (match[2]) {
+      case "ms":
+        total += n
+        break
+      case "s":
+        total += n * 1000
+        break
+      case "m":
+        total += n * 60_000
+        break
+      case "h":
+        total += n * 3_600_000
+        break
+    }
+  }
+  return total
+}

--- a/test/ratelimit.test.ts
+++ b/test/ratelimit.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest"
+import { parseRateLimitHeaders } from "../src/ratelimit/index.ts"
+
+function h(record: Record<string, string>): Headers {
+  return new Headers(record)
+}
+
+describe("parseRateLimitHeaders — OpenAI style", () => {
+  it("parses x-ratelimit-*-requests + -tokens together", () => {
+    const result = parseRateLimitHeaders(
+      h({
+        "x-ratelimit-limit-requests": "500",
+        "x-ratelimit-remaining-requests": "498",
+        "x-ratelimit-reset-requests": "30s",
+        "x-ratelimit-limit-tokens": "100000",
+        "x-ratelimit-remaining-tokens": "85000",
+        "x-ratelimit-reset-tokens": "1m20s",
+      }),
+    )
+    expect(result).not.toBeNull()
+    expect(result!.requests?.limit).toBe(500)
+    expect(result!.requests?.remaining).toBe(498)
+    expect(result!.requests?.resetAt).toBeInstanceOf(Date)
+    expect(result!.tokens?.limit).toBe(100_000)
+    expect(result!.tokens?.remaining).toBe(85_000)
+  })
+
+  it("only one bucket present", () => {
+    const result = parseRateLimitHeaders(
+      h({
+        "x-ratelimit-limit-requests": "60",
+        "x-ratelimit-remaining-requests": "59",
+      }),
+    )
+    expect(result?.requests?.limit).toBe(60)
+    expect(result?.tokens).toBeUndefined()
+  })
+})
+
+describe("parseRateLimitHeaders — IETF draft (RateLimit-*)", () => {
+  it("parses bare RateLimit-Limit / -Remaining / -Reset", () => {
+    const result = parseRateLimitHeaders(
+      h({
+        "ratelimit-limit": "100",
+        "ratelimit-remaining": "95",
+        "ratelimit-reset": "60",
+      }),
+    )
+    expect(result?.requests?.limit).toBe(100)
+    expect(result?.requests?.remaining).toBe(95)
+    expect(result?.requests?.resetAt).toBeInstanceOf(Date)
+    expect(result?.tokens).toBeUndefined()
+  })
+})
+
+describe("parseRateLimitHeaders — reset value formats", () => {
+  it("treats small integer as seconds-from-now", () => {
+    const before = Date.now()
+    const result = parseRateLimitHeaders(
+      h({ "x-ratelimit-reset-requests": "30", "x-ratelimit-limit-requests": "1" }),
+    )
+    const reset = result!.requests!.resetAt!
+    expect(reset.getTime()).toBeGreaterThanOrEqual(before + 29_900)
+    expect(reset.getTime()).toBeLessThanOrEqual(before + 30_500)
+  })
+
+  it("treats large integer as absolute Unix seconds", () => {
+    const result = parseRateLimitHeaders(
+      h({ "x-ratelimit-reset-requests": "1745680800", "x-ratelimit-limit-requests": "1" }),
+    )
+    const reset = result!.requests!.resetAt!
+    expect(reset.getTime()).toBe(1745680800 * 1000)
+  })
+
+  it("parses ISO 8601 reset", () => {
+    const result = parseRateLimitHeaders(
+      h({
+        "x-ratelimit-reset-requests": "2026-04-26T15:00:00Z",
+        "x-ratelimit-limit-requests": "1",
+      }),
+    )
+    expect(result!.requests!.resetAt!.toISOString()).toBe("2026-04-26T15:00:00.000Z")
+  })
+
+  it("parses duration suffix '500ms'", () => {
+    const before = Date.now()
+    const result = parseRateLimitHeaders(
+      h({ "x-ratelimit-reset-requests": "500ms", "x-ratelimit-limit-requests": "1" }),
+    )
+    const reset = result!.requests!.resetAt!
+    expect(reset.getTime() - before).toBeGreaterThanOrEqual(490)
+    expect(reset.getTime() - before).toBeLessThanOrEqual(550)
+  })
+
+  it("parses duration suffix '1m30s'", () => {
+    const before = Date.now()
+    const result = parseRateLimitHeaders(
+      h({ "x-ratelimit-reset-requests": "1m30s", "x-ratelimit-limit-requests": "1" }),
+    )
+    const reset = result!.requests!.resetAt!
+    expect(reset.getTime() - before).toBeGreaterThanOrEqual(89_900)
+    expect(reset.getTime() - before).toBeLessThanOrEqual(90_500)
+  })
+
+  it("parses duration suffix '2h15m'", () => {
+    const before = Date.now()
+    const result = parseRateLimitHeaders(
+      h({ "x-ratelimit-reset-requests": "2h15m", "x-ratelimit-limit-requests": "1" }),
+    )
+    const reset = result!.requests!.resetAt!
+    expect(reset.getTime() - before).toBeGreaterThanOrEqual(2 * 3600 * 1000 + 15 * 60 * 1000 - 100)
+  })
+
+  it("malformed reset value yields undefined", () => {
+    const result = parseRateLimitHeaders(
+      h({ "x-ratelimit-reset-requests": "tomorrow", "x-ratelimit-limit-requests": "1" }),
+    )
+    expect(result?.requests?.resetAt).toBeUndefined()
+  })
+})
+
+describe("parseRateLimitHeaders — edge cases", () => {
+  it("returns null when no recognized headers present", () => {
+    const result = parseRateLimitHeaders(h({ "content-type": "application/json" }))
+    expect(result).toBeNull()
+  })
+
+  it("returns bucket even if only limit is present", () => {
+    const result = parseRateLimitHeaders(h({ "ratelimit-limit": "100" }))
+    expect(result?.requests?.limit).toBe(100)
+    expect(result?.requests?.remaining).toBeUndefined()
+    expect(result?.requests?.resetAt).toBeUndefined()
+  })
+
+  it("OpenAI style takes precedence over generic when both present", () => {
+    const result = parseRateLimitHeaders(
+      h({
+        "x-ratelimit-limit-requests": "500",
+        "ratelimit-limit": "100", // ignored — OpenAI style won
+      }),
+    )
+    expect(result?.requests?.limit).toBe(500)
+  })
+
+  it("ignores non-numeric limit/remaining", () => {
+    const result = parseRateLimitHeaders(
+      h({
+        "x-ratelimit-limit-requests": "many",
+        "x-ratelimit-remaining-requests": "59",
+      }),
+    )
+    expect(result?.requests?.limit).toBeUndefined()
+    expect(result?.requests?.remaining).toBe(59)
+  })
+})


### PR DESCRIPTION
Closes #62.

New \`misina/ratelimit\` subpath. Parser-only — no runtime/middleware. Pairs naturally with \`onComplete\` for telemetry or with a future token-bucket limiter (#92) for proactive throttling.

## What it parses

**OpenAI / Anthropic style** (de-facto):
- \`x-ratelimit-{limit,remaining,reset}-requests\`
- \`x-ratelimit-{limit,remaining,reset}-tokens\`

**IETF draft** (\`draft-ietf-httpapi-ratelimit-headers\`):
- \`RateLimit-Limit\` / \`RateLimit-Remaining\` / \`RateLimit-Reset\`

Returns \`null\` when no recognized header is present.

## Reset value normalization

The \`reset\` header carries any of:
- **ISO 8601**: \`'2026-04-26T15:00:00Z'\`
- **Duration suffix**: \`'500ms'\`, \`'30s'\`, \`'1m30s'\`, \`'2h15m'\` (parses combinations)
- **Integer**:
  - small (\`< 100_000\`) → seconds-from-now (older drafts, Discord)
  - large → absolute Unix seconds (OpenAI, Cloudflare)

All normalized to a \`Date\`.

## Bucket precedence

When both styles co-exist on a response, the OpenAI-style buckets win — they're more specific. The IETF generic fills \`requests\` only when no OpenAI \`-requests\` bucket is found. The \`tokens\` bucket only populates from explicitly-suffixed headers (no double-reporting).

## API surface

\`\`\`ts
import { parseRateLimitHeaders } from 'misina/ratelimit'

const info = parseRateLimitHeaders(response.headers)
if (info?.requests) {
  console.log('requests left:', info.requests.remaining, 'reset at:', info.requests.resetAt)
}
\`\`\`

## Tests

481 → 495 (+14). Covers OpenAI both-buckets, IETF bare style, all four reset formats, edge cases (malformed, missing fields, non-numeric values).

## Bundle

Subpath \`misina/ratelimit\` budgeted at 2.5KB. Zero impact on core. Tree-shaken when not imported.