### PR TITLE
feat!: replace with* helpers with createMisina({ use: [...] }) plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,19 +104,19 @@
 - **`requestId`** on `MisinaResponse` and `HTTPError` — auto-scanned from `x-request-id` / `request-id` / `x-correlation-id`. Surfaced in error message as `[req: <id>]`.
 - **LLM SDK retry parity** — `retry-after-ms` (sub-second precision) + `x-should-retry` server hints honored by default.
 - **`Server-Timing` parser** — `MisinaResponse.serverTimings` populated automatically.
-- **W3C Trace Context** (`misina/tracing`) — `withTracing()` injects `traceparent` + `tracestate` + optional Baggage.
+- **W3C Trace Context** (`misina/tracing`) — `tracing()` injects `traceparent` + `tracestate` + optional Baggage.
 - **Rate-limit header parser** (`misina/ratelimit`) — handles OpenAI / Anthropic / IETF draft styles, normalizes reset values to `Date`.
 - **HTTP cache extras** — RFC 5861 `stale-while-revalidate` + `stale-if-error`, RFC 8246 `immutable`, plus an RFC 9211 `parseCacheStatus()` helper backed by the Structured Field Values parser.
 - **SSE reconnect** — `sseStreamReconnecting()` honors `Last-Event-ID`, the server's `retry:` field, and exponential backoff across disconnects (HTML §9.2.4).
 - **Request body compression** — opt-in `compressRequestBody: 'gzip' | 'deflate'` symmetrical with the response-side `decompress` knob.
 - **Cookie jar across redirects** — `Set-Cookie` issued by intermediate 30x hops is persisted (login flows that set the session on the redirect).
 - **Manual `composeSignals`** — fixes the Node #57736 listener-leak when long-lived AbortSignals are shared across many requests.
-- **RFC 9530 digest** (`misina/digest`) — `withDigest()` adds `Content-Digest` / `Repr-Digest` automatically; `verifyDigest()` validates incoming responses.
+- **RFC 9530 digest** (`misina/digest`) — `digestAuth()` adds `Content-Digest` / `Repr-Digest` automatically; `verifyDigest()` validates incoming responses.
 - **Resumable transfers** (`misina/transfer`) — `downloadResumable()` is Range-aware with per-chunk retries; `uploadResumable()` follows draft-ietf-httpbis-resumable-upload (POST + PATCH with `Upload-Offset`).
-- **OAuth helpers** (`misina/auth/oauth`) — `withJwtRefresh()` peeks `exp` and refreshes preemptively (single-flight); `createPkcePair()` + `exchangePkceCode()` for PKCE flows.
-- **AWS SigV4 signer** (`misina/auth/sigv4`) — `withSigV4()` adds `Authorization: AWS4-HMAC-SHA256 ...` + `x-amz-date` + `x-amz-content-sha256` to every request via Web Crypto. No `@aws-sdk/*` peer dep.
-- **RFC 9421 HTTP Message Signatures** (`misina/auth/signed`) — `withMessageSignature()` covers Ed25519 / ECDSA P-256 / RSA-PSS / HMAC-SHA256. Cloudflare Verified Bots / OpenAI Operator pattern.
-- **OpenTelemetry spans** (`misina/otel`) — `withOtel()` emits HTTP client spans with semconv attributes; tracer is duck-typed so misina never imports `@opentelemetry/*`.
+- **OAuth helpers** (`misina/auth/oauth`) — `jwtRefresh()` peeks `exp` and refreshes preemptively (single-flight); `createPkcePair()` + `exchangePkceCode()` for PKCE flows.
+- **AWS SigV4 signer** (`misina/auth/sigv4`) — `sigv4()` adds `Authorization: AWS4-HMAC-SHA256 ...` + `x-amz-date` + `x-amz-content-sha256` to every request via Web Crypto. No `@aws-sdk/*` peer dep.
+- **RFC 9421 HTTP Message Signatures** (`misina/auth/signed`) — `messageSignature()` covers Ed25519 / ECDSA P-256 / RSA-PSS / HMAC-SHA256. Cloudflare Verified Bots / OpenAI Operator pattern.
+- **OpenTelemetry spans** (`misina/otel`) — `otel()` emits HTTP client spans with semconv attributes; tracer is duck-typed so misina never imports `@opentelemetry/*`.
 - **Undici driver** (`misina/driver/undici`) — Node-only optional driver that takes any `undici.Agent` / `Pool` / `Client` so callers can tune connection pool, keep-alive, pipelining, and HTTP/2 multiplexing.
 - **node:http2 driver** (`misina/driver/http2`) — zero-dep alternative for environments that can't ship undici. Multiplexes streams over one session per origin; auto-reconnects on `GOAWAY`.
 - **VCR-lite test helpers** — `record()` + `recordToJSON()` + `replayFromJSON()` round-trip cassettes; `harToCassette()` imports HAR; `coverage()` flags unused routes; `randomStatus` / `randomNetworkError` for chaos; `misinaCallSerializer` redacts volatile headers in Vitest snapshots.
@@ -223,11 +223,14 @@ const api = createMisina({
   retry: 2, // number | false | RetryOptions
   responseType: undefined, // 'json' | 'text' | 'arrayBuffer' | 'blob' | 'stream'
 
-  // Hooks + drivers
+  // Hooks + drivers + plugins
   hooks: {
     /* init / beforeRequest / beforeRetry / beforeRedirect /
               afterResponse / beforeError / onComplete */
   },
+  use: [
+    /* MisinaPlugin[] — bearer(...), cache(...), breaker(...), ... */
+  ],
   driver: customDriver, // default: fetch driver
   defer: [], // late-binding callbacks
 
@@ -589,29 +592,92 @@ import { misinaCallSerializer } from "misina/test"
 expect.addSnapshotSerializer(misinaCallSerializer())
 ```
 
+### Plugins (`use: [...]`)
+
+Cross-cutting features (auth, cache, cookies, dedupe, breaker, rate limit,
+tracing, …) ship as **plugins** — small factories you drop into the `use`
+array on `createMisina`. Plugins are applied left-to-right: the first plugin
+is innermost, the last is outermost. Each plugin can contribute `hooks` and
+optionally a typed surface (`extend`) that gets intersected onto the
+returned client. See the per-feature subsections below for the full set.
+
+#### Writing your own plugin
+
+A plugin is a plain object satisfying `MisinaPlugin<TExt>`:
+
+```ts
+import type { MisinaPlugin } from "misina"
+
+export function timingHeader(name = "x-client-time"): MisinaPlugin {
+  return {
+    name: "timingHeader",
+    hooks: {
+      beforeRequest: (ctx) => {
+        const headers = new Headers(ctx.request.headers)
+        headers.set(name, String(Date.now()))
+        return new Request(ctx.request, { headers })
+      },
+    },
+  }
+}
+```
+
+Need to wrap the client itself (e.g. add a method, intercept every call)?
+Use the `extend` slot and declare what your plugin contributes via `TExt`:
+
+```ts
+import type { Misina, MisinaPlugin } from "misina"
+
+interface TraceHandle {
+  trace: { lastUrl: string | undefined }
+}
+
+export function traceLog(): MisinaPlugin<TraceHandle> {
+  const handle: TraceHandle["trace"] = { lastUrl: undefined }
+  return {
+    name: "traceLog",
+    extend: (misina): Misina & TraceHandle => ({ ...misina, trace: handle }),
+    hooks: {
+      afterResponse: (ctx) => {
+        handle.lastUrl = ctx.request.url
+      },
+    },
+  }
+}
+
+const api = createMisina({ baseURL, use: [traceLog()] })
+api.trace.lastUrl // ✓ typed
+```
+
+`TExt` must be a plain object literal — unions trigger TypeScript's
+intersection × union cross-product expansion, which gets expensive fast.
+
 ### misina/auth
 
 ```ts
-import { withBearer, withBasic, withRefreshOn401, withCsrf } from "misina/auth"
+import { createMisina } from "misina"
+import { basic, bearer, csrf, refreshOn401 } from "misina/auth"
 
-const api = withBearer(createMisina({ baseURL }), () => store.token)
-
-const refreshed = withRefreshOn401(api, {
-  refresh: async () => fetchNewToken(),
+const api = createMisina({
+  baseURL,
+  use: [
+    bearer(() => store.token),
+    refreshOn401({ refresh: async () => fetchNewToken() }),
+    csrf({ cookieName: "csrftoken", headerName: "X-CSRFToken" }),
+  ],
 })
-
-const django = withCsrf(api, { cookieName: "csrftoken", headerName: "X-CSRFToken" })
 ```
 
-`withRefreshOn401` collapses concurrent 401s into a single in-flight refresh.
+`refreshOn401` collapses concurrent 401s into a single in-flight refresh.
 
 ### misina/cookie
 
 ```ts
-import { withCookieJar, MemoryCookieJar } from "misina/cookie"
+import { createMisina } from "misina"
+import { cookieJar, MemoryCookieJar } from "misina/cookie"
 
 const jar = new MemoryCookieJar()
-const api = withCookieJar(createMisina({ baseURL }), jar)
+const api = createMisina({ baseURL, use: [cookieJar(jar)] })
 
 await api.post("/login", { user, pass }) // Set-Cookie stored
 await api.get("/profile") // Cookie sent automatically
@@ -620,13 +686,19 @@ await api.get("/profile") // Cookie sent automatically
 ### misina/cache
 
 ```ts
-import { withCache, memoryStore, parseCacheControl, parseCacheStatus } from "misina/cache"
+import { createMisina } from "misina"
+import { cache, memoryStore, parseCacheControl, parseCacheStatus } from "misina/cache"
 
-const api = withCache(createMisina({ baseURL }), {
-  store: memoryStore({ max: 500 }),
-  ttl: 60_000,
-  revalidate: true, // ETag / Last-Modified → 304 → reuse
-  honorCacheControl: true, // max-age, s-w-r, s-i-e, immutable, no-store
+const api = createMisina({
+  baseURL,
+  use: [
+    cache({
+      store: memoryStore({ max: 500 }),
+      ttl: 60_000,
+      revalidate: true, // ETag / Last-Modified → 304 → reuse
+      honorCacheControl: true, // max-age, s-w-r, s-i-e, immutable, no-store
+    }),
+  ],
 })
 
 // RFC 9111 + RFC 5861 + RFC 8246 directives are honored:
@@ -645,9 +717,10 @@ const status = parseCacheStatus(res.headers.get("cache-status")) // RFC 9211
 ### misina/dedupe
 
 ```ts
-import { withDedupe } from "misina/dedupe"
+import { createMisina } from "misina"
+import { dedupe } from "misina/dedupe"
 
-const api = withDedupe(createMisina({ baseURL }))
+const api = createMisina({ baseURL, use: [dedupe()] })
 // Concurrent identical GETs collapse onto one network request.
 ```
 
@@ -767,14 +840,20 @@ half-open ──[probe fails]──▶ open  (fresh timer)
 ```
 
 ```ts
-import { withCircuitBreaker, CircuitOpenError } from "misina/breaker"
+import { createMisina } from "misina"
+import { breaker, CircuitOpenError } from "misina/breaker"
 
-const api = withCircuitBreaker(misina, {
-  failureThreshold: 5, // trip after 5 failures
-  windowMs: 30_000, // sliding window
-  halfOpenAfter: 10_000, // ms before letting one probe through
-  // isFailure defaults to: any thrown error or 5xx HTTPError.
-  // 4xx is intentionally NOT counted (client mistake, not service degradation).
+const api = createMisina({
+  baseURL,
+  use: [
+    breaker({
+      failureThreshold: 5, // trip after 5 failures
+      windowMs: 30_000, // sliding window
+      halfOpenAfter: 10_000, // ms before letting one probe through
+      // isFailure defaults to: any thrown error or 5xx HTTPError.
+      // 4xx is intentionally NOT counted (client mistake, not service degradation).
+    }),
+  ],
 })
 
 try {
@@ -800,7 +879,8 @@ naturally with misina's driver pattern and adds zero deps.
 Parser for `x-ratelimit-*` headers + an in-process token bucket.
 
 ```ts
-import { parseRateLimitHeaders, withRateLimit } from "misina/ratelimit"
+import { createMisina } from "misina"
+import { parseRateLimitHeaders, rateLimit } from "misina/ratelimit"
 
 // Read what the server says.
 const info = parseRateLimitHeaders(response.headers)
@@ -808,14 +888,19 @@ console.log(info?.requests?.remaining, info?.tokens?.remaining)
 
 // Or wire a client-side limiter that gates dispatch and learns from
 // the response headers automatically:
-const api = withRateLimit(createMisina({ baseURL }), {
-  rpm: 500,
-  tpm: 100_000,
-  estimateTokens: (req) => approximateInputTokens(req),
+const api = createMisina({
+  baseURL,
+  use: [
+    rateLimit({
+      rpm: 500,
+      tpm: 100_000,
+      estimateTokens: (req) => approximateInputTokens(req),
+    }),
+  ],
 })
 ```
 
-`withRateLimit` acquires from both buckets in `beforeRequest`, snaps
+`rateLimit` acquires from both buckets in `beforeRequest`, snaps
 the buckets to the server's `x-ratelimit-remaining-*` numbers in
 `onComplete`, and parks both until `resetAt` on a 429. AbortSignal
 cancels a queued acquire.
@@ -830,22 +915,28 @@ W3C Trace Context propagator. Auto-injects `traceparent` and forwards
 `tracestate` on every outgoing request. Optional W3C Baggage header.
 
 ```ts
-import { withTracing } from "misina/tracing"
+import { createMisina } from "misina"
+import { tracing } from "misina/tracing"
 
-const api = withTracing(createMisina({ baseURL }))
+const api = createMisina({ baseURL, use: [tracing()] })
 // Each request gets a fresh `traceparent: 00-<32hex>-<16hex>-01`.
 
 // Compose with OpenTelemetry by reading the active span:
 import { trace } from "@opentelemetry/api"
 
-const apiOtel = withTracing(createMisina({ baseURL }), {
-  getCurrentSpan: () => {
-    const span = trace.getActiveSpan()
-    if (!span) return null
-    const ctx = span.spanContext()
-    return { traceId: ctx.traceId, parentId: ctx.spanId, flags: ctx.traceFlags }
-  },
-  baggage: { tenant: "acme", env: "prod" },
+const apiOtel = createMisina({
+  baseURL,
+  use: [
+    tracing({
+      getCurrentSpan: () => {
+        const span = trace.getActiveSpan()
+        if (!span) return null
+        const ctx = span.spanContext()
+        return { traceId: ctx.traceId, parentId: ctx.spanId, flags: ctx.traceFlags }
+      },
+      baggage: { tenant: "acme", env: "prod" },
+    }),
+  ],
 })
 ```
 
@@ -898,14 +989,16 @@ pool tweaks).
 
 ### misina/digest
 
-`withDigest(misina, opts?)` automatically adds `Content-Digest` (RFC 9530) on outgoing requests with a body. `verifyDigest(response)`
+The `digestAuth(opts?)` plugin automatically adds `Content-Digest`
+(RFC 9530) on outgoing requests with a body. `verifyDigest(response)`
 validates an incoming response and throws `DigestMismatchError` on
 failure.
 
 ```ts
-import { withDigest, verifyDigest } from "misina/digest"
+import { createMisina } from "misina"
+import { digestAuth, verifyDigest } from "misina/digest"
 
-const api = withDigest(createMisina({ baseURL }), { algorithm: "sha-256" })
+const api = createMisina({ baseURL, use: [digestAuth({ algorithm: "sha-256" })] })
 const res = await api.post("/upload", body) // Content-Digest: sha-256=:...:
 
 await verifyDigest(res.raw) // throws DigestMismatchError on mismatch
@@ -943,7 +1036,8 @@ doesn't advertise `Accept-Ranges: bytes`. Resumable upload reissues
 ### misina/auth/oauth
 
 ```ts
-import { createPkcePair, exchangePkceCode, withJwtRefresh } from "misina/auth/oauth"
+import { createMisina } from "misina"
+import { createPkcePair, exchangePkceCode, jwtRefresh } from "misina/auth/oauth"
 
 // 1. PKCE flow
 const pair = await createPkcePair() // { verifier, challenge, method: 'S256' }
@@ -958,32 +1052,38 @@ const tokens = await exchangePkceCode(misina, {
 })
 
 // 2. Proactive refresh (peeks JWT exp, single-flight under load)
-const api = withJwtRefresh(misina, {
-  getToken: () => store.token,
-  refresh: async () => {
-    const t = await refreshTokens()
-    store.token = t.access_token
-    return t.access_token
-  },
-  expiryWindowMs: 30_000,
+const api = createMisina({
+  baseURL,
+  use: [
+    jwtRefresh({
+      getToken: () => store.token,
+      refresh: async () => {
+        const t = await refreshTokens()
+        store.token = t.access_token
+        return t.access_token
+      },
+      expiryWindowMs: 30_000,
+    }),
+  ],
 })
 ```
 
 ### misina/auth/sigv4
 
 ```ts
-import { withSigV4 } from "misina/auth/sigv4"
+import { createMisina } from "misina"
+import { sigv4 } from "misina/auth/sigv4"
 
-const api = withSigV4(
-  createMisina({
-    baseURL: "https://bedrock-runtime.us-east-1.amazonaws.com",
-  }),
-  {
-    service: "bedrock-runtime",
-    region: "us-east-1",
-    credentials: async () => fromEnvOrIam(), // any provider returning { accessKeyId, secretAccessKey, sessionToken? }
-  },
-)
+const api = createMisina({
+  baseURL: "https://bedrock-runtime.us-east-1.amazonaws.com",
+  use: [
+    sigv4({
+      service: "bedrock-runtime",
+      region: "us-east-1",
+      credentials: async () => fromEnvOrIam(), // any provider returning { accessKeyId, secretAccessKey, sessionToken? }
+    }),
+  ],
+})
 
 // Every request now carries Authorization: AWS4-HMAC-SHA256 ...,
 // x-amz-date, x-amz-content-sha256, and (when present) x-amz-security-token.
@@ -992,28 +1092,39 @@ const api = withSigV4(
 Streaming uploads: pass `unsignedPayload: true` to use
 `x-amz-content-sha256: UNSIGNED-PAYLOAD` instead of buffering the body
 to hash it. `signRequest(request, opts)` is exported separately for
-one-off signing without wrapping the misina instance.
+one-off signing without wiring the plugin.
 
 ### misina/auth/signed
 
 ```ts
-import { withMessageSignature } from "misina/auth/signed"
+import { createMisina } from "misina"
+import { messageSignature } from "misina/auth/signed"
 
 // 1. Asymmetric: Web Crypto Ed25519 keypair
 const pair = await crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"])
-const api = withMessageSignature(createMisina({ baseURL }), {
-  keyId: "my-bot",
-  algorithm: "ed25519",
-  privateKey: pair.privateKey,
-  components: ["@method", "@target-uri", "@authority", "content-type", "content-digest"],
+const api = createMisina({
+  baseURL,
+  use: [
+    messageSignature({
+      keyId: "my-bot",
+      algorithm: "ed25519",
+      privateKey: pair.privateKey,
+      components: ["@method", "@target-uri", "@authority", "content-type", "content-digest"],
+    }),
+  ],
 })
 
 // 2. Shared secret: HMAC-SHA256 (raw Uint8Array works)
-const api2 = withMessageSignature(createMisina({ baseURL }), {
-  keyId: "shared",
-  algorithm: "hmac-sha256",
-  privateKey: new TextEncoder().encode(process.env.SHARED_SECRET!),
-  components: ["@method", "@target-uri"],
+const api2 = createMisina({
+  baseURL,
+  use: [
+    messageSignature({
+      keyId: "shared",
+      algorithm: "hmac-sha256",
+      privateKey: new TextEncoder().encode(process.env.SHARED_SECRET!),
+      components: ["@method", "@target-uri"],
+    }),
+  ],
 })
 ```
 
@@ -1035,13 +1146,19 @@ prevention).
 
 ```ts
 import { trace } from "@opentelemetry/api"
-import { withOtel } from "misina/otel"
+import { createMisina } from "misina"
+import { otel } from "misina/otel"
 
-const api = withOtel(createMisina({ baseURL }), {
-  tracer: trace.getTracer("my-service"),
-  // optional:
-  spanName: (req) => `http.${req.method.toLowerCase()} ${new URL(req.url).pathname}`,
-  attributes: { "deployment.environment": process.env.NODE_ENV },
+const api = createMisina({
+  baseURL,
+  use: [
+    otel({
+      tracer: trace.getTracer("my-service"),
+      // optional:
+      spanName: (req) => `http.${req.method.toLowerCase()} ${new URL(req.url).pathname}`,
+      attributes: { "deployment.environment": process.env.NODE_ENV },
+    }),
+  ],
 })
 ```
 
@@ -1051,7 +1168,7 @@ standard semconv attributes — `http.request.method`, `url.full`,
 on start; `http.response.status_code` on completion. Errors call
 `span.recordException(err)` and set status `ERROR`. `traceparent` is
 auto-injected from the active span context; pass
-`injectTraceparent: false` when `withTracing` is already in the chain
+`injectTraceparent: false` when `tracing()` is already in the chain
 to avoid double injection.
 
 Peer-dep duck-typed: anything matching the minimal `{ startSpan }`
@@ -1063,13 +1180,19 @@ memory exporter for tests, or your own wrapper. misina never imports
 
 ```ts
 import * as Sentry from "@sentry/browser"
-import { withSentry } from "misina/sentry"
+import { createMisina } from "misina"
+import { sentry } from "misina/sentry"
 
-const api = withSentry(createMisina({ baseURL }), {
-  Sentry,
-  captureLevel: "error", // 'all' | 'error' (skip 4xx, default) | '5xx'
-  redactHeaders: ["authorization", "cookie", "x-api-key"],
-  successBreadcrumb: true, // add a breadcrumb on every 2xx
+const api = createMisina({
+  baseURL,
+  use: [
+    sentry({
+      Sentry,
+      captureLevel: "error", // 'all' | 'error' (skip 4xx, default) | '5xx'
+      redactHeaders: ["authorization", "cookie", "x-api-key"],
+      successBreadcrumb: true, // add a breadcrumb on every 2xx
+    }),
+  ],
 })
 ```
 
@@ -1099,10 +1222,16 @@ actually ran.
 
 ### misina/graphql
 
-```ts
-import { withGraphql } from "misina/graphql"
+GraphQL doesn't fit the misina plugin shape (it returns a `GraphqlClient`,
+not a `Misina`). Use it as a sibling helper layered on top of a misina
+instance.
 
-const gql = withGraphql(createMisina({ baseURL }), {
+```ts
+import { createMisina } from "misina"
+import { createGraphqlClient } from "misina/graphql"
+
+const misina = createMisina({ baseURL })
+const gql = createGraphqlClient(misina, {
   endpoint: "/graphql",
   persistedQueries: true, // Apollo APQ (SHA-256, GET fallback for short queries)
 })
@@ -1370,7 +1499,7 @@ const api3 = createMisina({
 ```
 
 `durationMs` already accounts for retries; `error` is populated only
-on the failure branch. Pair with `withTracing` / `withOtel` when
+on the failure branch. Pair with `tracing()` / `otel()` when
 distributed-tracing context belongs in the same log line.
 
 ## Benchmarks

--- a/scripts/bundle-budget.mjs
+++ b/scripts/bundle-budget.mjs
@@ -10,7 +10,7 @@ const DIST = resolve(process.cwd(), "dist")
 const BUDGETS = [
   // Core surface — must stay tight
   { match: (p) => p === "index.mjs", max: 12_000, label: "core" },
-  { match: (p) => p === "misina.mjs", max: 23_000, label: "core engine" },
+  { match: (p) => p === "misina.mjs", max: 24_000, label: "core engine" },
 
   // Internal helpers
   { match: (p) => /^_[\w-]+\.mjs$/.test(p), max: 6_000, label: "internal" },
@@ -26,7 +26,7 @@ const BUDGETS = [
   { match: (p) => p.startsWith("cache/"), max: 9_500, label: "cache" },
   { match: (p) => p.startsWith("auth/"), max: 6_000, label: "auth" },
   { match: (p) => p.startsWith("cookie/"), max: 6_000, label: "cookie" },
-  { match: (p) => p.startsWith("digest/"), max: 3_000, label: "digest" },
+  { match: (p) => p.startsWith("digest/"), max: 3_100, label: "digest" },
   { match: (p) => p.startsWith("transfer/"), max: 5_500, label: "transfer" },
   { match: (p) => p.startsWith("test/"), max: 8_500, label: "test" },
   { match: (p) => p.startsWith("breaker/"), max: 4_000, label: "breaker" },

--- a/src/_merge.ts
+++ b/src/_merge.ts
@@ -82,7 +82,10 @@ function copyInto(out: Record<string, string>, source: HeadersInput): void {
   }
 }
 
-function mergeHookConfigs(a: MisinaHooks | undefined, b: MisinaHooks | undefined): MisinaHooks {
+export function mergeHookConfigs(
+  a: MisinaHooks | undefined,
+  b: MisinaHooks | undefined,
+): MisinaHooks {
   if (!a) return b ?? {}
   if (!b) return a
   return {

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,14 +1,15 @@
-import type { Misina, MisinaContext } from "../types.ts"
+import type { Misina, MisinaContext, MisinaPlugin } from "../types.ts"
 
 export type TokenSource = string | (() => string | Promise<string>)
 
 /**
- * Add a `Authorization: Bearer <token>` header to every request. Token can
+ * Add an `Authorization: Bearer <token>` header to every request. Token can
  * be a string, a function, or a function returning a Promise — fetched once
  * per request.
  */
-export function withBearer(misina: Misina, source: TokenSource): Misina {
-  return misina.extend({
+export function bearer(source: TokenSource): MisinaPlugin {
+  return {
+    name: "bearer",
     hooks: {
       beforeRequest: async (ctx) => {
         const token = await resolveToken(source)
@@ -18,15 +19,16 @@ export function withBearer(misina: Misina, source: TokenSource): Misina {
         return new Request(ctx.request, { headers })
       },
     },
-  })
+  }
 }
 
 /**
- * Add a `Authorization: Basic <base64>` header. Username and password are
+ * Add an `Authorization: Basic <base64>` header. Username and password are
  * base64'd on each request — function form supported for rotation.
  */
-export function withBasic(misina: Misina, user: TokenSource, pass: TokenSource): Misina {
-  return misina.extend({
+export function basic(user: TokenSource, pass: TokenSource): MisinaPlugin {
+  return {
+    name: "basic",
     hooks: {
       beforeRequest: async (ctx) => {
         const u = await resolveToken(user)
@@ -36,7 +38,7 @@ export function withBasic(misina: Misina, user: TokenSource, pass: TokenSource):
         return new Request(ctx.request, { headers })
       },
     },
-  })
+  }
 }
 
 export interface RefreshOn401Options {
@@ -53,8 +55,11 @@ export interface RefreshOn401Options {
  * concurrent 401s share a single in-flight refresh (mutex). A retried
  * request that itself returns 401 is NOT refreshed again — it surfaces to
  * the caller so they can prompt for re-login.
+ *
+ * Uses the `extend` slot because the afterResponse hook needs a reference
+ * to the surrounding misina to dispatch the retry call.
  */
-export function withRefreshOn401(misina: Misina, opts: RefreshOn401Options): Misina {
+export function refreshOn401(opts: RefreshOn401Options): MisinaPlugin {
   let inflight: Promise<string> | undefined
   const shouldRefresh = opts.shouldRefresh ?? ((ctx) => ctx.response?.status === 401)
   // Tracks responses that came from a refresh-retry path. afterResponse
@@ -72,23 +77,27 @@ export function withRefreshOn401(misina: Misina, opts: RefreshOn401Options): Mis
     return inflight
   }
 
-  return misina.extend({
-    hooks: {
-      afterResponse: async (ctx) => {
-        if (!ctx.response) return
-        if (retriedResponses.has(ctx.response)) return
-        if (!shouldRefresh(ctx)) return
+  return {
+    name: "refreshOn401",
+    extend: (misina) =>
+      misina.extend({
+        hooks: {
+          afterResponse: async (ctx) => {
+            if (!ctx.response) return
+            if (retriedResponses.has(ctx.response)) return
+            if (!shouldRefresh(ctx)) return
 
-        const newToken = await getNewToken()
-        const headers = { ...ctx.options.headers }
-        headers["authorization"] = `Bearer ${newToken}`
+            const newToken = await getNewToken()
+            const headers = { ...ctx.options.headers }
+            headers["authorization"] = `Bearer ${newToken}`
 
-        const fresh = await fetchOnce(misina, ctx.request, headers)
-        retriedResponses.add(fresh)
-        return fresh
-      },
-    },
-  })
+            const fresh = await fetchOnce(misina, ctx.request, headers)
+            retriedResponses.add(fresh)
+            return fresh
+          },
+        },
+      }),
+  }
 }
 
 async function fetchOnce(
@@ -115,20 +124,20 @@ async function fetchOnce(
  * Read a CSRF token from a cookie and echo it as a header. Common in
  * Django/Rails/Laravel apps.
  */
-export function withCsrf(
-  misina: Misina,
+export function csrf(
   opts: {
     cookieName?: string
     headerName?: string
     /** Read cookies. Default: `document.cookie` in browser. */
     getCookies?: () => string
   } = {},
-): Misina {
+): MisinaPlugin {
   const cookieName = opts.cookieName ?? "XSRF-TOKEN"
   const headerName = opts.headerName ?? "X-XSRF-TOKEN"
   const getCookies = opts.getCookies ?? defaultGetCookies
 
-  return misina.extend({
+  return {
+    name: "csrf",
     hooks: {
       beforeRequest: (ctx) => {
         const cookies = safeCall(getCookies)
@@ -140,7 +149,7 @@ export function withCsrf(
         return new Request(ctx.request, { headers })
       },
     },
-  })
+  }
 }
 
 function defaultGetCookies(): string {

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -1,8 +1,8 @@
 /**
  * OAuth 2.1 / PKCE helpers and JWT-aware refresh.
  *
- * `withJwtRefresh(misina, opts)` peeks the JWT exp claim on every request
- * and proactively refreshes the token *before* a 401 round-trip. Concurrent
+ * `jwtRefresh(opts)` peeks the JWT exp claim on every request and
+ * proactively refreshes the token *before* a 401 round-trip. Concurrent
  * requests with an expired token collapse onto a single refresh call.
  *
  * `createPkcePair()` generates a code verifier + S256 challenge per RFC
@@ -10,10 +10,10 @@
  * exchange (RFC 6749 §4.1.3) with the verifier attached.
  */
 
-import type { Misina, MisinaContext } from "../types.ts"
+import type { Misina, MisinaContext, MisinaPlugin } from "../types.ts"
 
 /* ----------------------------------------------------------------------- */
-/*                            withJwtRefresh                                */
+/*                              jwtRefresh                                  */
 /* ----------------------------------------------------------------------- */
 
 export interface JwtRefreshOptions {
@@ -47,7 +47,7 @@ export interface JwtRefreshOptions {
  * Refresh runs in `beforeRequest`, so the *current* request goes out with
  * the new token — no extra 401 round-trip.
  */
-export function withJwtRefresh(misina: Misina, opts: JwtRefreshOptions): Misina {
+export function jwtRefresh(opts: JwtRefreshOptions): MisinaPlugin {
   const window = opts.expiryWindowMs ?? 30_000
   const rejectIfUnchanged = opts.rejectIfUnchanged ?? true
   let inflight: Promise<string> | undefined
@@ -57,7 +57,7 @@ export function withJwtRefresh(misina: Misina, opts: JwtRefreshOptions): Misina 
       inflight = Promise.resolve(opts.refresh())
         .then((next) => {
           if (rejectIfUnchanged && current && next === current) {
-            throw new Error("withJwtRefresh: refresh returned the same token")
+            throw new Error("jwtRefresh: refresh returned the same token")
           }
           return next
         })
@@ -70,7 +70,8 @@ export function withJwtRefresh(misina: Misina, opts: JwtRefreshOptions): Misina 
     return inflight
   }
 
-  return misina.extend({
+  return {
+    name: "jwtRefresh",
     hooks: {
       beforeRequest: async (ctx) => {
         if (opts.shouldRefresh && !opts.shouldRefresh(ctx)) return
@@ -87,7 +88,7 @@ export function withJwtRefresh(misina: Misina, opts: JwtRefreshOptions): Misina 
         return new Request(ctx.request, { headers })
       },
     },
-  })
+  }
 }
 
 /**

--- a/src/auth/signed.ts
+++ b/src/auth/signed.ts
@@ -24,19 +24,25 @@
  *
  * @example
  * ```ts
- * import { withMessageSignature } from "misina/auth/signed"
+ * import { createMisina } from "misina"
+ * import { messageSignature } from "misina/auth/signed"
  *
  * const keyPair = await crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"])
- * const api = withMessageSignature(createMisina({ baseURL }), {
- *   keyId: "my-key",
- *   privateKey: keyPair.privateKey,
- *   algorithm: "ed25519",
- *   components: ["@method", "@target-uri", "content-type", "content-digest"],
+ * const api = createMisina({
+ *   baseURL,
+ *   use: [
+ *     messageSignature({
+ *       keyId: "my-key",
+ *       privateKey: keyPair.privateKey,
+ *       algorithm: "ed25519",
+ *       components: ["@method", "@target-uri", "content-type", "content-digest"],
+ *     }),
+ *   ],
  * })
  * ```
  */
 
-import type { Misina } from "../types.ts"
+import type { MisinaPlugin } from "../types.ts"
 
 export type MessageSignatureAlgorithm =
   | "ed25519"
@@ -84,17 +90,17 @@ const DEFAULT_COMPONENTS: readonly string[] = [
 ]
 
 /**
- * Wrap a Misina with automatic RFC 9421 signing on every outgoing
- * request. The hook builds the signature base, signs it with the
- * caller's key, and writes `Signature-Input` + `Signature` to the
- * request headers.
+ * Sign every outgoing request per RFC 9421. The hook builds the signature
+ * base, signs it with the caller's key, and writes `Signature-Input` +
+ * `Signature` to the request headers.
  */
-export function withMessageSignature(misina: Misina, options: MessageSignatureOptions): Misina {
-  return misina.extend({
+export function messageSignature(options: MessageSignatureOptions): MisinaPlugin {
+  return {
+    name: "messageSignature",
     hooks: {
       beforeRequest: async (ctx) => signRequest(ctx.request, options),
     },
-  })
+  }
 }
 
 /**

--- a/src/auth/sigv4.ts
+++ b/src/auth/sigv4.ts
@@ -1,8 +1,8 @@
 /**
  * AWS Signature Version 4 signer — zero-dep, Web Crypto only.
  *
- * `withSigV4(misina, opts)` is a Misina extension that signs every
- * outgoing request with the standard AWS SigV4 algorithm:
+ * `sigv4(opts)` is a Misina plugin that signs every outgoing request with
+ * the standard AWS SigV4 algorithm:
  *
  *   1. Build the canonical request (method + canonical URI + canonical
  *      query + canonical headers + signed-headers list + payload hash).
@@ -19,17 +19,23 @@
  *
  * @example
  * ```ts
- * import { withSigV4 } from "misina/auth/sigv4"
+ * import { createMisina } from "misina"
+ * import { sigv4 } from "misina/auth/sigv4"
  *
- * const api = withSigV4(createMisina({ baseURL: "https://bedrock-runtime.us-east-1.amazonaws.com" }), {
- *   service: "bedrock-runtime",
- *   region: "us-east-1",
- *   credentials: async () => ({ accessKeyId, secretAccessKey, sessionToken }),
+ * const api = createMisina({
+ *   baseURL: "https://bedrock-runtime.us-east-1.amazonaws.com",
+ *   use: [
+ *     sigv4({
+ *       service: "bedrock-runtime",
+ *       region: "us-east-1",
+ *       credentials: async () => ({ accessKeyId, secretAccessKey, sessionToken }),
+ *     }),
+ *   ],
  * })
  * ```
  */
 
-import type { Misina } from "../types.ts"
+import type { MisinaPlugin } from "../types.ts"
 
 export interface SigV4Credentials {
   accessKeyId: string
@@ -52,12 +58,13 @@ export interface SigV4Options {
 const ALGORITHM = "AWS4-HMAC-SHA256"
 
 /**
- * Wrap a Misina with automatic SigV4 signing. Runs as a `beforeRequest`
- * hook so the Request that hits the driver already carries
- * `Authorization`, `x-amz-date`, and `x-amz-content-sha256`.
+ * Sign every request with AWS SigV4. Runs as a `beforeRequest` hook so the
+ * Request that hits the driver already carries `Authorization`,
+ * `x-amz-date`, and `x-amz-content-sha256`.
  */
-export function withSigV4(misina: Misina, options: SigV4Options): Misina {
-  return misina.extend({
+export function sigv4(options: SigV4Options): MisinaPlugin {
+  return {
+    name: "sigv4",
     hooks: {
       beforeRequest: async (ctx) => {
         const creds =
@@ -72,7 +79,7 @@ export function withSigV4(misina: Misina, options: SigV4Options): Misina {
         })
       },
     },
-  })
+  }
 }
 
 export interface SignRequestOptions {

--- a/src/breaker/index.ts
+++ b/src/breaker/index.ts
@@ -1,5 +1,10 @@
 import { MisinaError } from "../errors/base.ts"
-import type { Misina, MisinaContext, MisinaRequestInit, MisinaResponsePromise } from "../types.ts"
+import type {
+  MisinaContext,
+  MisinaPlugin,
+  MisinaRequestInit,
+  MisinaResponsePromise,
+} from "../types.ts"
 import { catchable } from "../_catch.ts"
 
 /**
@@ -71,19 +76,17 @@ function defaultIsFailure({ error }: BreakerCallResult): boolean {
 }
 
 /**
- * Wrap a Misina with a circuit breaker.
+ * Plugin that fronts a Misina with a circuit breaker. Adds a `.breaker`
+ * handle on the returned client for inspection and manual control.
  *
  * ```ts
- * const api = withCircuitBreaker(misina, { failureThreshold: 3 })
+ * const api = createMisina({ use: [breaker({ failureThreshold: 3 })] })
+ * api.breaker.state() // "closed" | "open" | "half-open"
  * ```
- *
- * Returns the wrapped misina; the breaker handle for inspection/control is
- * available via the `.breaker` extension on the returned object.
  */
-export function withCircuitBreaker(
-  misina: Misina,
+export function breaker(
   opts: CircuitBreakerOptions = {},
-): Misina & { breaker: BreakerHandle } {
+): MisinaPlugin<{ breaker: BreakerHandle }> {
   const failureThreshold = opts.failureThreshold ?? DEFAULT_OPTS.failureThreshold
   const windowMs = opts.windowMs ?? DEFAULT_OPTS.windowMs
   const halfOpenAfter = opts.halfOpenAfter ?? DEFAULT_OPTS.halfOpenAfter
@@ -174,30 +177,33 @@ export function withCircuitBreaker(
     return catchable(promise) as MisinaResponsePromise<T>
   }
 
-  const breaker: BreakerHandle = {
+  const handle: BreakerHandle = {
     state: () => state,
     trip: () => transitionToOpen(Date.now()),
     reset: () => recordSuccess(),
   }
 
   return {
-    ...misina,
-    breaker,
-    request: <T = unknown>(input: string, init?: MisinaRequestInit) =>
-      wrap<T>(() => misina.request<T>(input, init)),
-    get: <T = unknown>(url: string, init?: MisinaRequestInit) =>
-      wrap<T>(() => misina.get<T>(url, init)),
-    head: <T = unknown>(url: string, init?: MisinaRequestInit) =>
-      wrap<T>(() => misina.head<T>(url, init)),
-    options: <T = unknown>(url: string, init?: MisinaRequestInit) =>
-      wrap<T>(() => misina.options<T>(url, init)),
-    delete: <T = unknown>(url: string, init?: MisinaRequestInit) =>
-      wrap<T>(() => misina.delete<T>(url, init)),
-    post: <T = unknown>(url: string, body?: unknown, init?: MisinaRequestInit) =>
-      wrap<T>(() => misina.post<T>(url, body, init)),
-    put: <T = unknown>(url: string, body?: unknown, init?: MisinaRequestInit) =>
-      wrap<T>(() => misina.put<T>(url, body, init)),
-    patch: <T = unknown>(url: string, body?: unknown, init?: MisinaRequestInit) =>
-      wrap<T>(() => misina.patch<T>(url, body, init)),
+    name: "breaker",
+    extend: (misina) => ({
+      ...misina,
+      breaker: handle,
+      request: <T = unknown>(input: string, init?: MisinaRequestInit) =>
+        wrap<T>(() => misina.request<T>(input, init)),
+      get: <T = unknown>(url: string, init?: MisinaRequestInit) =>
+        wrap<T>(() => misina.get<T>(url, init)),
+      head: <T = unknown>(url: string, init?: MisinaRequestInit) =>
+        wrap<T>(() => misina.head<T>(url, init)),
+      options: <T = unknown>(url: string, init?: MisinaRequestInit) =>
+        wrap<T>(() => misina.options<T>(url, init)),
+      delete: <T = unknown>(url: string, init?: MisinaRequestInit) =>
+        wrap<T>(() => misina.delete<T>(url, init)),
+      post: <T = unknown>(url: string, body?: unknown, init?: MisinaRequestInit) =>
+        wrap<T>(() => misina.post<T>(url, body, init)),
+      put: <T = unknown>(url: string, body?: unknown, init?: MisinaRequestInit) =>
+        wrap<T>(() => misina.put<T>(url, body, init)),
+      patch: <T = unknown>(url: string, body?: unknown, init?: MisinaRequestInit) =>
+        wrap<T>(() => misina.patch<T>(url, body, init)),
+    }),
   }
 }

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,5 +1,5 @@
 import { parseSfList, type SfBareItem } from "../_sf.ts"
-import type { HttpMethod, Misina, MisinaContext } from "../types.ts"
+import type { HttpMethod, MisinaContext, MisinaPlugin } from "../types.ts"
 
 export interface CacheEntry {
   response: Response
@@ -241,7 +241,7 @@ const DEFAULT_METHODS: HttpMethod[] = ["GET"]
  * `Cache-Control: no-store` (skip cache), `Cache-Control: max-age=N`
  * (override TTL), and ETag / Last-Modified for revalidation.
  */
-export function withCache(misina: Misina, opts: CacheOptions = {}): Misina {
+export function cache(opts: CacheOptions = {}): MisinaPlugin {
   const store = opts.store ?? memoryStore()
   const ttl = opts.ttl ?? 60_000
   const methods = opts.methods ?? DEFAULT_METHODS
@@ -249,7 +249,8 @@ export function withCache(misina: Misina, opts: CacheOptions = {}): Misina {
   const revalidate = opts.revalidate !== false
   const honorCacheControl = opts.honorCacheControl !== false
 
-  return misina.extend({
+  return {
+    name: "cache",
     hooks: {
       beforeRequest: async (ctx) => {
         if (!methods.includes(ctx.options.method)) return
@@ -365,7 +366,7 @@ export function withCache(misina: Misina, opts: CacheOptions = {}): Misina {
         }
       },
     },
-  })
+  }
 }
 
 function variantKeyFor(

--- a/src/cookie/index.ts
+++ b/src/cookie/index.ts
@@ -1,4 +1,4 @@
-import type { Misina } from "../types.ts"
+import type { MisinaPlugin } from "../types.ts"
 
 export interface CookieJar {
   getCookieString: (url: string) => string | Promise<string>
@@ -56,11 +56,12 @@ export class MemoryCookieJar implements CookieJar {
 }
 
 /**
- * Wrap a Misina instance with a cookie jar. Adds a Cookie header on every
- * request matching the URL; reads `Set-Cookie` from responses and stores them.
+ * Plugin that adds a `Cookie` header on every request matching the URL and
+ * reads `Set-Cookie` from responses to populate the jar.
  */
-export function withCookieJar(misina: Misina, jar: CookieJar): Misina {
-  return misina.extend({
+export function cookieJar(jar: CookieJar): MisinaPlugin {
+  return {
+    name: "cookieJar",
     hooks: {
       beforeRequest: async (ctx) => {
         const cookieString = await jar.getCookieString(ctx.request.url)
@@ -109,7 +110,7 @@ export function withCookieJar(misina: Misina, jar: CookieJar): Misina {
         }
       },
     },
-  })
+  }
 }
 
 function parseSetCookie(header: string, url: string): StoredCookie | undefined {

--- a/src/dedupe/index.ts
+++ b/src/dedupe/index.ts
@@ -1,7 +1,7 @@
 import { catchable } from "../_catch.ts"
 import type {
   HttpMethod,
-  Misina,
+  MisinaPlugin,
   MisinaRequestInit,
   MisinaResponse,
   MisinaResponsePromise,
@@ -17,72 +17,68 @@ export interface DedupeOptions {
 }
 
 /**
- * Wrap a Misina so concurrent identical requests share a single in-flight
- * promise. Each waiter receives the same body (response.raw is cloned per
- * waiter so each can read it independently).
+ * Plugin that collapses concurrent identical requests onto a single
+ * in-flight promise. Each waiter receives the same `MisinaResponse` —
+ * `response.raw` is shared, so callers wanting to re-read the body via
+ * `.raw.text()` should clone it first.
  *
  * Defaults to safe methods only — de-duping POST is risky.
  */
-export function withDedupe(misina: Misina, opts: DedupeOptions = {}): Misina {
+export function dedupe(opts: DedupeOptions = {}): MisinaPlugin {
   const methods = opts.methods ?? DEFAULT_METHODS
   const computeKey =
     opts.key ?? ((input, init) => `${(init?.method ?? "GET").toUpperCase()} ${input}`)
   const inflight = new Map<string, Promise<MisinaResponse<unknown>>>()
 
-  function dedupedRequest<T>(input: string, init?: MisinaRequestInit): MisinaResponsePromise<T> {
-    const method = (init?.method ?? "GET").toUpperCase() as HttpMethod
-    if (!methods.includes(method)) return misina.request<T>(input, init)
-
-    const key = computeKey(input, init)
-    const existing = inflight.get(key)
-    if (existing) {
-      // Each waiter gets the same MisinaResponse — `data` is already parsed
-      // (immutable from the user's POV), `raw` is shared. If a waiter needs
-      // to re-read the body via `.raw.text()` etc, they should clone it
-      // themselves before consuming.
-      return catchable(existing.then((res) => res as MisinaResponse<T>)) as MisinaResponsePromise<T>
-    }
-
-    const underlying = misina.request<T>(input, init)
-    // Track without disturbing the user-facing promise: a separate `.then`
-    // chain feeds the inflight Map; the user keeps the original catchable.
-    const tracked = underlying.then((res) => res as MisinaResponse<unknown>)
-    // Both inner branches need a `.catch` so an unhandled-rejection warning
-    // doesn't fire when only `underlying` is awaited by the caller.
-    tracked.catch(() => {})
-    underlying
-      .finally(() => {
-        // Free the slot the moment the underlying request settles. Concurrent
-        // callers that bind `existing` _before_ the request settles share the
-        // same promise; once it settles, sequential callers (after `await`)
-        // get a fresh request — which is what users expect.
-        inflight.delete(key)
-      })
-      .catch(() => {})
-    inflight.set(key, tracked)
-    return underlying
-  }
-
-  // Re-bind every shorthand to the deduped request — including mutating
-  // methods, since `methods` may opt POST/PUT/PATCH/DELETE in. Non-listed
-  // methods short-circuit inside `dedupedRequest` to the underlying call.
   return {
-    ...misina,
-    request: <T = unknown>(input: string, init?: MisinaRequestInit) =>
-      dedupedRequest<T>(input, init),
-    get: <T = unknown>(url: string, init?: MisinaRequestInit) =>
-      dedupedRequest<T>(url, { ...init, method: "GET" }),
-    head: <T = unknown>(url: string, init?: MisinaRequestInit) =>
-      dedupedRequest<T>(url, { ...init, method: "HEAD" }),
-    options: <T = unknown>(url: string, init?: MisinaRequestInit) =>
-      dedupedRequest<T>(url, { ...init, method: "OPTIONS" }),
-    delete: <T = unknown>(url: string, init?: MisinaRequestInit) =>
-      dedupedRequest<T>(url, { ...init, method: "DELETE" }),
-    post: <T = unknown>(url: string, body?: unknown, init?: MisinaRequestInit) =>
-      dedupedRequest<T>(url, { ...init, method: "POST", body }),
-    put: <T = unknown>(url: string, body?: unknown, init?: MisinaRequestInit) =>
-      dedupedRequest<T>(url, { ...init, method: "PUT", body }),
-    patch: <T = unknown>(url: string, body?: unknown, init?: MisinaRequestInit) =>
-      dedupedRequest<T>(url, { ...init, method: "PATCH", body }),
+    name: "dedupe",
+    extend: (misina) => {
+      function dedupedRequest<T>(
+        input: string,
+        init?: MisinaRequestInit,
+      ): MisinaResponsePromise<T> {
+        const method = (init?.method ?? "GET").toUpperCase() as HttpMethod
+        if (!methods.includes(method)) return misina.request<T>(input, init)
+
+        const key = computeKey(input, init)
+        const existing = inflight.get(key)
+        if (existing) {
+          return catchable(
+            existing.then((res) => res as MisinaResponse<T>),
+          ) as MisinaResponsePromise<T>
+        }
+
+        const underlying = misina.request<T>(input, init)
+        const tracked = underlying.then((res) => res as MisinaResponse<unknown>)
+        tracked.catch(() => {})
+        underlying
+          .finally(() => {
+            inflight.delete(key)
+          })
+          .catch(() => {})
+        inflight.set(key, tracked)
+        return underlying
+      }
+
+      return {
+        ...misina,
+        request: <T = unknown>(input: string, init?: MisinaRequestInit) =>
+          dedupedRequest<T>(input, init),
+        get: <T = unknown>(url: string, init?: MisinaRequestInit) =>
+          dedupedRequest<T>(url, { ...init, method: "GET" }),
+        head: <T = unknown>(url: string, init?: MisinaRequestInit) =>
+          dedupedRequest<T>(url, { ...init, method: "HEAD" }),
+        options: <T = unknown>(url: string, init?: MisinaRequestInit) =>
+          dedupedRequest<T>(url, { ...init, method: "OPTIONS" }),
+        delete: <T = unknown>(url: string, init?: MisinaRequestInit) =>
+          dedupedRequest<T>(url, { ...init, method: "DELETE" }),
+        post: <T = unknown>(url: string, body?: unknown, init?: MisinaRequestInit) =>
+          dedupedRequest<T>(url, { ...init, method: "POST", body }),
+        put: <T = unknown>(url: string, body?: unknown, init?: MisinaRequestInit) =>
+          dedupedRequest<T>(url, { ...init, method: "PUT", body }),
+        patch: <T = unknown>(url: string, body?: unknown, init?: MisinaRequestInit) =>
+          dedupedRequest<T>(url, { ...init, method: "PATCH", body }),
+      }
+    },
   }
 }

--- a/src/digest/index.ts
+++ b/src/digest/index.ts
@@ -1,30 +1,30 @@
 /**
  * RFC 9530 Digest Fields — `Content-Digest` and `Repr-Digest`.
  *
- * `withDigest(misina, opts)` automatically computes a digest of the
- * outgoing request body and attaches it as a Structured Field
- * dictionary header. `verifyDigest(response)` reads the digest from a
- * received response and verifies it against the body bytes; mismatch
- * throws `DigestMismatchError`.
+ * `digestAuth(opts)` automatically computes a digest of the outgoing
+ * request body and attaches it as a Structured Field dictionary header.
+ * `verifyDigest(response)` reads the digest from a received response and
+ * verifies it against the body bytes; mismatch throws `DigestMismatchError`.
  *
- * Hashes are computed via `crypto.subtle.digest` so any runtime with
- * the Web Crypto API (Node ≥ 19, Bun, Deno, browsers) works without a
+ * Hashes are computed via `crypto.subtle.digest` so any runtime with the
+ * Web Crypto API (Node ≥ 19, Bun, Deno, browsers) works without a
  * polyfill. Bodies that arrive as `ReadableStream` are tee'd so the
  * caller's body remains readable — we drain one branch into the digest
  * input and pass the other along to the wire.
  *
  * @example
  * ```ts
- * import { withDigest, verifyDigest } from "misina/digest"
+ * import { createMisina } from "misina"
+ * import { digestAuth, verifyDigest } from "misina/digest"
  *
- * const api = withDigest(createMisina({ baseURL }), { algorithm: "sha-256" })
+ * const api = createMisina({ baseURL, use: [digestAuth({ algorithm: "sha-256" })] })
  * const res = await api.post("/upload", body) // Content-Digest auto-added
  *
  * await verifyDigest(res.raw) // throws DigestMismatchError on mismatch
  * ```
  */
 
-import type { Misina } from "../types.ts"
+import type { MisinaPlugin } from "../types.ts"
 
 export type DigestAlgorithm = "sha-256" | "sha-512"
 
@@ -65,21 +65,21 @@ const ALGO_TO_SUBTLE: Record<DigestAlgorithm, string> = {
 }
 
 /**
- * Wrap a Misina with automatic `Content-Digest` (or `Repr-Digest`)
- * generation on outgoing requests. The hook reads the body bytes,
- * digests them with `crypto.subtle.digest`, and writes a Structured
- * Field dictionary entry of the form `<algo>=:<base64>:` to the
- * configured header.
+ * Plugin that automatically generates a `Content-Digest` (or `Repr-Digest`)
+ * header on outgoing requests. The hook reads the body bytes, digests them
+ * with `crypto.subtle.digest`, and writes a Structured Field dictionary
+ * entry of the form `<algo>=:<base64>:` to the configured header.
  *
- * If the request has no body (or `skipEmptyBody` is true and the body
- * is empty) the header is not added.
+ * If the request has no body (or `skipEmptyBody` is true and the body is
+ * empty) the header is not added.
  */
-export function withDigest(misina: Misina, options: DigestOptions = {}): Misina {
+export function digestAuth(options: DigestOptions = {}): MisinaPlugin {
   const algorithm = options.algorithm ?? "sha-256"
   const field = options.field ?? "content-digest"
   const skipEmptyBody = options.skipEmptyBody ?? true
 
-  return misina.extend({
+  return {
+    name: "digestAuth",
     hooks: {
       beforeRequest: async (ctx) => {
         const original = ctx.request
@@ -108,7 +108,7 @@ export function withDigest(misina: Misina, options: DigestOptions = {}): Misina 
         })
       },
     },
-  })
+  }
 }
 
 /**

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -11,11 +11,17 @@
  * to take advantage of CDN caching. Auto-disabled for mutations and
  * for queries above ~1500 chars (URL length safety).
  *
+ * Note: GraphQL doesn't fit the misina plugin shape because it returns a
+ * different surface (`GraphqlClient`), not a `Misina`. Use it as a sibling
+ * helper layered on top of a misina instance.
+ *
  * @example
  * ```ts
- * import { withGraphql } from "misina/graphql"
+ * import { createMisina } from "misina"
+ * import { createGraphqlClient } from "misina/graphql"
  *
- * const gql = withGraphql(createMisina({ baseURL }), { endpoint: "/graphql" })
+ * const misina = createMisina({ baseURL })
+ * const gql = createGraphqlClient(misina, { endpoint: "/graphql" })
  * const data = await gql.query<User>(`query GetUser($id: ID!) { user(id: $id) { id name } }`, { id: "42" })
  * ```
  */
@@ -80,7 +86,7 @@ export class GraphqlAggregateError extends Error {
   }
 }
 
-export function withGraphql(misina: Misina, options: GraphqlOptions = {}): GraphqlClient {
+export function createGraphqlClient(misina: Misina, options: GraphqlOptions = {}): GraphqlClient {
   const endpoint = options.endpoint ?? "/graphql"
   const apq = options.persistedQueries ?? false
   const getFallbackBelow = options.getFallbackBelow ?? 0

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export {
 
 export type {
   AfterResponseHook,
+  ApplyPlugins,
   ArrayFormat,
   BeforeErrorHook,
   BeforeRedirectHook,
@@ -60,6 +61,7 @@ export type {
   MisinaHooks,
   MisinaMeta,
   MisinaOptions,
+  MisinaPlugin,
   MisinaState,
   MisinaRequestInit,
   MisinaResolvedOptions,

--- a/src/misina.ts
+++ b/src/misina.ts
@@ -2,7 +2,7 @@ import { isPayloadMethod, parseResponseBody, serializeBody } from "./_body.ts"
 import { catchable } from "./_catch.ts"
 import { compressBody, resolveCompressFormat } from "./_compress.ts"
 import { mergeHooks } from "./_hooks.ts"
-import { mergeOptions } from "./_merge.ts"
+import { mergeHookConfigs, mergeOptions } from "./_merge.ts"
 import {
   acceptEncodingFor,
   type DecompressFormat,
@@ -32,11 +32,14 @@ import {
   TimeoutError,
 } from "./errors/index.ts"
 import type {
+  ApplyPlugins,
   HttpMethod,
   Misina,
   MisinaContext,
   MisinaDriver,
+  MisinaHooks,
   MisinaOptions,
+  MisinaPlugin,
   MisinaRequestInit,
   MisinaResolvedOptions,
   MisinaResponse,
@@ -59,7 +62,15 @@ const DEFAULT_TIMEOUT = 10_000
 // to RequestInit and onto MisinaResolvedOptions.
 const RUNTIME_KEYS = ["cf", "tls", "unix", "proxy", "verbose", "client"] as const
 
-export function createMisina(defaults: MisinaOptions = {}): Misina {
+export function createMisina<const TPlugins extends readonly MisinaPlugin<any>[] = []>(
+  options: MisinaOptions & { use?: TPlugins } = {} as MisinaOptions & { use?: TPlugins },
+): ApplyPlugins<TPlugins> {
+  const plugins = (options.use ?? []) as readonly MisinaPlugin<any>[]
+  warnDuplicatePluginNames(plugins)
+  // Plugin hooks are concatenated *before* the user's hooks so a
+  // user-supplied hook always runs after every plugin contribution and gets
+  // the final word on the request/response.
+  const defaults: MisinaOptions = applyPluginHooks(options, plugins)
   const driver: MisinaDriver =
     defaults.driver ?? fetchDriverFactory({ fetch: defaults.fetch } as never)
   // Per-instance shared state. Same reference returned to every call so
@@ -453,7 +464,53 @@ export function createMisina(defaults: MisinaOptions = {}): Misina {
     safe,
   }
 
-  return misina
+  // Apply plugin `extend` wrappers in left-to-right order. The first plugin
+  // is innermost; the last is outermost. A wrapping plugin (e.g. circuit
+  // breaker) placed after a hook-only plugin observes that hook's effects
+  // on every call it admits. Returned typed surfaces (e.g. { breaker })
+  // accumulate via `ApplyPlugins<TPlugins>`.
+  let result: Misina = misina
+  for (const plugin of plugins) {
+    if (plugin.extend) result = plugin.extend(result)
+  }
+  return result as ApplyPlugins<TPlugins>
+}
+
+/**
+ * Concatenate every plugin's hooks onto `options.hooks` in plugin order.
+ * Plugin hooks land first so any user-supplied `options.hooks` runs last
+ * (final-word semantics).
+ */
+function applyPluginHooks(
+  options: MisinaOptions & { use?: unknown },
+  plugins: readonly MisinaPlugin<any>[],
+): MisinaOptions {
+  // Strip `use` so `extend()` (which deep-merges defaults with child overrides)
+  // can't re-feed plugins into the loop on the child instance — that would
+  // re-run every wrapping plugin and recurse infinitely.
+  const { use: _use, ...rest } = options
+  void _use
+  if (plugins.length === 0) return rest
+  let merged: MisinaHooks | undefined
+  for (const plugin of plugins) {
+    if (plugin.hooks) merged = mergeHookConfigs(merged, plugin.hooks)
+  }
+  if (rest.hooks) merged = mergeHookConfigs(merged, rest.hooks)
+  return { ...rest, hooks: merged }
+}
+
+function warnDuplicatePluginNames(plugins: readonly MisinaPlugin<any>[]): void {
+  if (plugins.length < 2) return
+  const seen = new Set<string>()
+  for (const plugin of plugins) {
+    if (seen.has(plugin.name)) {
+      // Duplicates are usually a copy-paste error or an accidental double-
+      // registration. We don't throw — both plugins still get applied —
+      // but we surface the problem so users notice in dev.
+      console.warn(`misina: duplicate plugin name "${plugin.name}" in createMisina({ use: [...] })`)
+    }
+    seen.add(plugin.name)
+  }
 }
 
 function resolveOptions(

--- a/src/otel/index.ts
+++ b/src/otel/index.ts
@@ -8,23 +8,25 @@
  * fake fits, your own wrapper fits). Lets users opt into spans without
  * misina ever importing `@opentelemetry/*`.
  *
- * Complements `misina/tracing`: `withTracing` is the W3C trace context
- * *propagator* (sets `traceparent` / `baggage`); `withOtel` is the
+ * Complements `misina/tracing`: `tracing()` is the W3C trace context
+ * *propagator* (sets `traceparent` / `baggage`); `otel()` is the
  * *span emitter* (creates and ends spans, attaches semconv attributes,
  * records exceptions). Use one, the other, or both.
  *
  * @example
  * ```ts
  * import { trace } from "@opentelemetry/api"
- * import { withOtel } from "misina/otel"
+ * import { createMisina } from "misina"
+ * import { otel } from "misina/otel"
  *
- * const api = withOtel(createMisina({ baseURL }), {
- *   tracer: trace.getTracer("my-service"),
+ * const api = createMisina({
+ *   baseURL,
+ *   use: [otel({ tracer: trace.getTracer("my-service") })],
  * })
  * ```
  */
 
-import type { Misina } from "../types.ts"
+import type { MisinaPlugin } from "../types.ts"
 
 /** Minimal SpanContext shape used to format `traceparent`. */
 export interface OtelSpanContext {
@@ -74,17 +76,18 @@ const SPAN_KIND_CLIENT = 2
 const STATUS_ERROR = 2
 
 /**
- * Wrap a Misina with OpenTelemetry HTTP client spans. One span per
- * request lifetime: started in `beforeRequest`, ended in `onComplete`.
- * The span is associated with the live `Request` via a WeakMap so we
- * survive `extend()` chains and per-request hook copies.
+ * Plugin that emits OpenTelemetry HTTP client spans. One span per request
+ * lifetime: started in `beforeRequest`, ended in `onComplete`. The span is
+ * associated with the live `Request` via a WeakMap so we survive
+ * `extend()` chains and per-request hook copies.
  */
-export function withOtel(misina: Misina, options: OtelOptions): Misina {
+export function otel(options: OtelOptions): MisinaPlugin {
   const inject = options.injectTraceparent ?? true
   const spans = new WeakMap<Request, OtelSpan>()
   const nameOf = options.spanName ?? ((req) => `HTTP ${req.method}`)
 
-  return misina.extend({
+  return {
+    name: "otel",
     hooks: {
       beforeRequest: (ctx) => {
         const url = new URL(ctx.request.url)
@@ -131,7 +134,7 @@ export function withOtel(misina: Misina, options: OtelOptions): Misina {
         span.end()
       },
     },
-  })
+  }
 }
 
 function formatTraceparent(sc: OtelSpanContext): string {

--- a/src/ratelimit/index.ts
+++ b/src/ratelimit/index.ts
@@ -8,7 +8,7 @@
  *   headers, and backs off on 429.
  */
 
-import type { Misina } from "../types.ts"
+import type { MisinaPlugin } from "../types.ts"
 
 export interface RateLimitBucket {
   limit: number | undefined
@@ -140,14 +140,15 @@ export interface RateLimitOptions {
  * to the real budget the server reports. 429 responses drain both
  * buckets aggressively so subsequent calls back off.
  */
-export function withRateLimit(misina: Misina, options: RateLimitOptions = {}): Misina {
+export function rateLimit(options: RateLimitOptions = {}): MisinaPlugin {
   const now = options.now ?? ((): number => Date.now())
   const estimate = options.estimateTokens ?? ((): number => 0)
 
   const requests = createBucket(options.rpm ?? Number.POSITIVE_INFINITY, now)
   const tokens = createBucket(options.tpm ?? Number.POSITIVE_INFINITY, now)
 
-  return misina.extend({
+  return {
+    name: "rateLimit",
     hooks: {
       beforeRequest: async (ctx) => {
         const cost = Math.max(0, estimate(ctx.request))
@@ -169,7 +170,7 @@ export function withRateLimit(misina: Misina, options: RateLimitOptions = {}): M
         }
       },
     },
-  })
+  }
 }
 
 interface Bucket {

--- a/src/sentry/index.ts
+++ b/src/sentry/index.ts
@@ -9,17 +9,17 @@
  * @example
  * ```ts
  * import * as Sentry from "@sentry/browser"
- * import { withSentry } from "misina/sentry"
+ * import { createMisina } from "misina"
+ * import { sentry } from "misina/sentry"
  *
- * const api = withSentry(createMisina({ baseURL }), {
- *   Sentry,
- *   captureLevel: "error",
- *   redactHeaders: ["authorization", "cookie"],
+ * const api = createMisina({
+ *   baseURL,
+ *   use: [sentry({ Sentry, captureLevel: "error", redactHeaders: ["authorization", "cookie"] })],
  * })
  * ```
  */
 
-import type { Misina } from "../types.ts"
+import type { MisinaPlugin } from "../types.ts"
 
 /** Minimal Sentry surface used by the adapter. */
 export interface SentryHub {
@@ -58,12 +58,13 @@ export interface SentryOptions {
 
 const DEFAULT_REDACT = ["authorization", "cookie", "proxy-authorization"]
 
-export function withSentry(misina: Misina, options: SentryOptions): Misina {
+export function sentry(options: SentryOptions): MisinaPlugin {
   const captureLevel = options.captureLevel ?? "error"
   const redact = new Set((options.redactHeaders ?? DEFAULT_REDACT).map((h) => h.toLowerCase()))
   const successBreadcrumb = options.successBreadcrumb ?? false
 
-  return misina.extend({
+  return {
+    name: "sentry",
     hooks: {
       beforeError: (error, ctx) => {
         if (!shouldCapture(error, captureLevel)) return error
@@ -95,7 +96,7 @@ export function withSentry(misina: Misina, options: SentryOptions): Misina {
         })
       },
     },
-  })
+  }
 }
 
 function shouldCapture(error: unknown, level: "all" | "error" | "5xx"): boolean {

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -11,23 +11,29 @@
  *
  * @example
  * ```ts
- * import { withTracing } from 'misina/tracing'
+ * import { createMisina } from 'misina'
+ * import { tracing } from 'misina/tracing'
  *
- * const api = withTracing(createMisina({ baseURL }))
+ * const api = createMisina({ baseURL, use: [tracing()] })
  * await api.get('/users/42') // request gets a fresh traceparent + matching tracestate
  *
  * // With OpenTelemetry:
  * import { trace } from '@opentelemetry/api'
- * const api2 = withTracing(misina, {
- *   getCurrentSpan: () => {
- *     const span = trace.getActiveSpan()
- *     return span ? { traceId: span.spanContext().traceId, parentId: span.spanContext().spanId } : null
- *   },
+ * const api2 = createMisina({
+ *   baseURL,
+ *   use: [
+ *     tracing({
+ *       getCurrentSpan: () => {
+ *         const span = trace.getActiveSpan()
+ *         return span ? { traceId: span.spanContext().traceId, parentId: span.spanContext().spanId } : null
+ *       },
+ *     }),
+ *   ],
  * })
  * ```
  */
 
-import type { Misina } from "../types.ts"
+import type { MisinaPlugin } from "../types.ts"
 
 export interface TracingOptions {
   /**
@@ -81,9 +87,10 @@ function buildBaggage(entries: Record<string, string>): string | null {
   return parts.length === 0 ? null : parts.join(",")
 }
 
-export function withTracing(misina: Misina, options: TracingOptions = {}): Misina {
+export function tracing(options: TracingOptions = {}): MisinaPlugin {
   const flagsDefault = options.flags ?? 0x01
-  return misina.extend({
+  return {
+    name: "tracing",
     hooks: {
       beforeRequest: (ctx) => {
         // Don't overwrite a caller-supplied traceparent — they may have
@@ -108,5 +115,5 @@ export function withTracing(misina: Misina, options: TracingOptions = {}): Misin
         return new Request(ctx.request, { headers })
       },
     },
-  })
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -639,6 +639,45 @@ export interface Misina {
 }
 
 /**
+ * Plugin shape consumed by `createMisina({ use: [...] })`. A plugin contributes
+ * one or both of:
+ *
+ * - `hooks` — concatenated into the instance's hook chain in plugin order.
+ * - `extend` — wraps the constructed `Misina`, optionally adding a typed
+ *   surface (`TExt`) that gets intersected onto the returned client.
+ *
+ * `TExt` must be an object literal — unions are forbidden because they would
+ * cross-product through the resulting intersection (TS performance trap).
+ *
+ * Plugins are applied left-to-right: the first plugin is innermost, the last
+ * is outermost. A wrapping plugin (e.g. circuit breaker) placed *after* a
+ * hook-only plugin will see the hook's effects on every call it admits.
+ */
+export interface MisinaPlugin<TExt extends object = {}> {
+  /** Identifier for diagnostics and duplicate detection. */
+  readonly name: string
+  /** Hooks merged into the instance hook chain. */
+  readonly hooks?: MisinaHooks
+  /** Wraps the built Misina; may add a typed surface. */
+  readonly extend?: (misina: Misina) => Misina & TExt
+}
+
+/**
+ * Tail-recursive accumulator that intersects every plugin's `TExt` onto the
+ * base `Misina` type. Tuple-destructuring keeps recursion identity stable so
+ * the TypeScript checker uses the tail-recursion fast path (depth ≤ 1000).
+ */
+export type ApplyPlugins<
+  TPlugins extends readonly MisinaPlugin<any>[],
+  TAcc = Misina,
+> = TPlugins extends readonly [
+  MisinaPlugin<infer TExt>,
+  ...infer TRest extends readonly MisinaPlugin<any>[],
+]
+  ? ApplyPlugins<TRest, TAcc & TExt>
+  : TAcc
+
+/**
  * Driver interface — pluggable transport. Drivers receive a real `Request` and
  * return a real `Response`, keeping the `Web Fetch API` shape canonical.
  */

--- a/test/auth-edges.test.ts
+++ b/test/auth-edges.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
-import { withBasic, withBearer, withCsrf, withRefreshOn401 } from "../src/auth/index.ts"
+import { basic, bearer, csrf, refreshOn401 } from "../src/auth/index.ts"
 
 function recordingDriver() {
   const seen: { url: string; auth: string | null; csrf: string | null }[] = []
@@ -20,17 +20,17 @@ function recordingDriver() {
   }
 }
 
-describe("withBearer — token edge cases", () => {
+describe("bearer — token edge cases", () => {
   it("empty token: header is not set", async () => {
     const { seen, driver } = recordingDriver()
-    const m = withBearer(createMisina({ driver, retry: 0 }), "")
+    const m = createMisina({ driver, retry: 0, use: [bearer("")] })
     await m.get("https://api.test/")
     expect(seen[0]?.auth).toBeNull()
   })
 
   it("function returning empty: header is not set", async () => {
     const { seen, driver } = recordingDriver()
-    const m = withBearer(createMisina({ driver, retry: 0 }), () => "")
+    const m = createMisina({ driver, retry: 0, use: [bearer(() => "")] })
     await m.get("https://api.test/")
     expect(seen[0]?.auth).toBeNull()
   })
@@ -38,25 +38,25 @@ describe("withBearer — token edge cases", () => {
   it("async function source: token resolved per-request", async () => {
     const { seen, driver } = recordingDriver()
     let n = 0
-    const m = withBearer(createMisina({ driver, retry: 0 }), async () => `t${++n}`)
+    const m = createMisina({ driver, retry: 0, use: [bearer(async () => `t${++n}`)] })
     await m.get("https://api.test/a")
     await m.get("https://api.test/b")
     expect(seen[0]?.auth).toBe("Bearer t1")
     expect(seen[1]?.auth).toBe("Bearer t2")
   })
 
-  it("user-supplied auth header is overridden by withBearer", async () => {
+  it("user-supplied auth header is overridden by bearer", async () => {
     const { seen, driver } = recordingDriver()
-    const m = withBearer(createMisina({ driver, retry: 0 }), "from-bearer")
+    const m = createMisina({ driver, retry: 0, use: [bearer("from-bearer")] })
     await m.get("https://api.test/", { headers: { authorization: "from-call" } })
     expect(seen[0]?.auth).toBe("Bearer from-bearer")
   })
 })
 
-describe("withBasic — encoding edges", () => {
+describe("basic — encoding edges", () => {
   it("ASCII credentials encode correctly", async () => {
     const { seen, driver } = recordingDriver()
-    const m = withBasic(createMisina({ driver, retry: 0 }), "alice", "secret")
+    const m = createMisina({ driver, retry: 0, use: [basic("alice", "secret")] })
     await m.get("https://api.test/")
     // base64("alice:secret") = "YWxpY2U6c2VjcmV0"
     expect(seen[0]?.auth).toBe("Basic YWxpY2U6c2VjcmV0")
@@ -65,7 +65,7 @@ describe("withBasic — encoding edges", () => {
   it("non-ASCII (Turkish chars) credentials encode as UTF-8, not Latin1", async () => {
     const { seen, driver } = recordingDriver()
     // "şifre" — has a non-Latin1 char, would crash naive btoa.
-    const m = withBasic(createMisina({ driver, retry: 0 }), "kullanıcı", "şifre")
+    const m = createMisina({ driver, retry: 0, use: [basic("kullanıcı", "şifre")] })
     await m.get("https://api.test/")
     // Decode back via atob → bytes → utf8 string.
     const auth = seen[0]?.auth ?? ""
@@ -80,22 +80,29 @@ describe("withBasic — encoding edges", () => {
   it("function-form credentials are resolved per request", async () => {
     const { seen, driver } = recordingDriver()
     let i = 0
-    const m = withBasic(
-      createMisina({ driver, retry: 0 }),
-      () => `user${++i}`,
-      () => "pwd",
-    )
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        basic(
+          () => `user${++i}`,
+          () => "pwd",
+        ),
+      ],
+    })
     await m.get("https://api.test/a")
     await m.get("https://api.test/b")
     expect(seen[0]?.auth).not.toBe(seen[1]?.auth)
   })
 })
 
-describe("withCsrf — cookie patterns", () => {
+describe("csrf — cookie patterns", () => {
   it("reads token from cookie and sets header", async () => {
     const { seen, driver } = recordingDriver()
-    const m = withCsrf(createMisina({ driver, retry: 0 }), {
-      getCookies: () => "XSRF-TOKEN=abc123; sessionid=xyz",
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [csrf({ getCookies: () => "XSRF-TOKEN=abc123; sessionid=xyz" })],
     })
     await m.get("https://api.test/")
     expect(seen[0]?.csrf).toBe("abc123")
@@ -103,8 +110,10 @@ describe("withCsrf — cookie patterns", () => {
 
   it("URL-encoded cookie value is decoded", async () => {
     const { seen, driver } = recordingDriver()
-    const m = withCsrf(createMisina({ driver, retry: 0 }), {
-      getCookies: () => "XSRF-TOKEN=token%2Bwith%3Dpadding",
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [csrf({ getCookies: () => "XSRF-TOKEN=token%2Bwith%3Dpadding" })],
     })
     await m.get("https://api.test/")
     expect(seen[0]?.csrf).toBe("token+with=padding")
@@ -112,8 +121,10 @@ describe("withCsrf — cookie patterns", () => {
 
   it("missing cookie: header not set", async () => {
     const { seen, driver } = recordingDriver()
-    const m = withCsrf(createMisina({ driver, retry: 0 }), {
-      getCookies: () => "irrelevant=value",
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [csrf({ getCookies: () => "irrelevant=value" })],
     })
     await m.get("https://api.test/")
     expect(seen[0]?.csrf).toBeNull()
@@ -121,9 +132,15 @@ describe("withCsrf — cookie patterns", () => {
 
   it("cookie name with regex metacharacters is escaped", async () => {
     const { seen, driver } = recordingDriver()
-    const m = withCsrf(createMisina({ driver, retry: 0 }), {
-      cookieName: "csrf.token+v2",
-      getCookies: () => "csrf.token+v2=safe",
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        csrf({
+          cookieName: "csrf.token+v2",
+          getCookies: () => "csrf.token+v2=safe",
+        }),
+      ],
     })
     await m.get("https://api.test/")
     expect(seen[0]?.csrf).toBe("safe")
@@ -138,9 +155,15 @@ describe("withCsrf — cookie patterns", () => {
         return new Response("{}", { headers: { "content-type": "application/json" } })
       },
     }
-    const m = withCsrf(createMisina({ driver, retry: 0 }), {
-      headerName: "X-CSRF-Token",
-      getCookies: () => "XSRF-TOKEN=abc",
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        csrf({
+          headerName: "X-CSRF-Token",
+          getCookies: () => "XSRF-TOKEN=abc",
+        }),
+      ],
     })
     await m.get("https://api.test/")
     expect(xsrfHeader).toBe("abc")
@@ -148,10 +171,16 @@ describe("withCsrf — cookie patterns", () => {
 
   it("getCookies throwing is gracefully handled", async () => {
     const { seen, driver } = recordingDriver()
-    const m = withCsrf(createMisina({ driver, retry: 0 }), {
-      getCookies: () => {
-        throw new Error("no document")
-      },
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        csrf({
+          getCookies: () => {
+            throw new Error("no document")
+          },
+        }),
+      ],
     })
     // Must not throw — request goes through without csrf header.
     await m.get("https://api.test/")
@@ -159,7 +188,7 @@ describe("withCsrf — cookie patterns", () => {
   })
 })
 
-describe("withRefreshOn401 — additional edges", () => {
+describe("refreshOn401 — additional edges", () => {
   it("Bearer is replaced after refresh, even if app supplies its own auth header", async () => {
     let attempts = 0
     const driver = {
@@ -182,8 +211,7 @@ describe("withRefreshOn401 — additional edges", () => {
       },
     }
 
-    const misina = createMisina({ driver, retry: 0 })
-    const api = withRefreshOn401(misina, { refresh: () => "NEW" })
+    const api = createMisina({ driver, retry: 0, use: [refreshOn401({ refresh: () => "NEW" })] })
 
     const res = await api.get<{ ok: boolean }>("https://api.test/", {
       headers: { authorization: "Bearer OLD" },
@@ -204,10 +232,15 @@ describe("withRefreshOn401 — additional edges", () => {
         })
       },
     }
-    const misina = createMisina({ driver, retry: 0 })
-    const api = withRefreshOn401(misina, {
-      refresh: () => "NEW",
-      shouldRefresh: (ctx) => ctx.response?.status === 419,
+    const api = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        refreshOn401({
+          refresh: () => "NEW",
+          shouldRefresh: (ctx) => ctx.response?.status === 419,
+        }),
+      ],
     })
 
     const res = await api.get("https://api.test/")

--- a/test/auth-oauth.test.ts
+++ b/test/auth-oauth.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
-import { createPkcePair, exchangePkceCode, peekJwtExp, withJwtRefresh } from "../src/auth/oauth.ts"
+import { createPkcePair, exchangePkceCode, jwtRefresh, peekJwtExp } from "../src/auth/oauth.ts"
 
 function makeJwt(payload: Record<string, unknown>): string {
   // Header doesn't matter for peekJwtExp; signature segment can be empty.
@@ -26,7 +26,7 @@ describe("peekJwtExp", () => {
   })
 })
 
-describe("withJwtRefresh", () => {
+describe("jwtRefresh", () => {
   it("refreshes proactively when the JWT is about to expire", async () => {
     const expiringExp = Math.floor(Date.now() / 1000) + 5 // 5s left
     let token = makeJwt({ exp: expiringExp })
@@ -39,14 +39,20 @@ describe("withJwtRefresh", () => {
         return new Response("ok", { status: 200 })
       },
     }
-    const m = withJwtRefresh(createMisina({ driver, retry: 0 }), {
-      getToken: () => token,
-      refresh: async () => {
-        refreshes++
-        token = makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 })
-        return token
-      },
-      expiryWindowMs: 30_000, // refresh anything < 30s left
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        jwtRefresh({
+          getToken: () => token,
+          refresh: async () => {
+            refreshes++
+            token = makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 })
+            return token
+          },
+          expiryWindowMs: 30_000, // refresh anything < 30s left
+        }),
+      ],
     })
     await m.get("https://x.test/", { headers: { authorization: `Bearer ${token}` } })
     expect(refreshes).toBe(1)
@@ -60,12 +66,18 @@ describe("withJwtRefresh", () => {
       name: "x",
       request: async () => new Response("ok", { status: 200 }),
     }
-    const m = withJwtRefresh(createMisina({ driver, retry: 0 }), {
-      getToken: () => token,
-      refresh: async () => {
-        refreshes++
-        return token
-      },
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        jwtRefresh({
+          getToken: () => token,
+          refresh: async () => {
+            refreshes++
+            return token
+          },
+        }),
+      ],
     })
     await m.get("https://x.test/", { headers: { authorization: `Bearer ${token}` } })
     expect(refreshes).toBe(0)
@@ -79,15 +91,21 @@ describe("withJwtRefresh", () => {
       name: "x",
       request: async () => new Response("ok", { status: 200 }),
     }
-    const m = withJwtRefresh(createMisina({ driver, retry: 0 }), {
-      getToken: () => token,
-      refresh: async () => {
-        refreshes++
-        await new Promise((r) => setTimeout(r, 5))
-        token = makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 })
-        return token
-      },
-      expiryWindowMs: 30_000,
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        jwtRefresh({
+          getToken: () => token,
+          refresh: async () => {
+            refreshes++
+            await new Promise((r) => setTimeout(r, 5))
+            token = makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 })
+            return token
+          },
+          expiryWindowMs: 30_000,
+        }),
+      ],
     })
     await Promise.all([
       m.get("https://x.test/a", { headers: { authorization: `Bearer ${token}` } }),
@@ -103,9 +121,15 @@ describe("withJwtRefresh", () => {
       name: "x",
       request: async () => new Response("ok", { status: 200 }),
     }
-    const m = withJwtRefresh(createMisina({ driver, retry: 0 }), {
-      getToken: () => token,
-      refresh: () => token, // unchanged — bug scenario
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        jwtRefresh({
+          getToken: () => token,
+          refresh: () => token, // unchanged — bug scenario
+        }),
+      ],
     })
     await expect(
       m.get("https://x.test/", { headers: { authorization: `Bearer ${token}` } }),

--- a/test/auth-paginate.test.ts
+++ b/test/auth-paginate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
-import { withRefreshOn401 } from "../src/auth/index.ts"
+import { refreshOn401 } from "../src/auth/index.ts"
 import { paginate } from "../src/paginate/index.ts"
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
@@ -10,7 +10,7 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   })
 }
 
-describe("withRefreshOn401 — race + recursion (Bug 47)", () => {
+describe("refreshOn401 — race + recursion (Bug 47)", () => {
   it("collapses concurrent 401s onto a single refresh call", async () => {
     let refreshCount = 0
     let token = "old"
@@ -24,7 +24,7 @@ describe("withRefreshOn401 — race + recursion (Bug 47)", () => {
       },
     }
 
-    const misina = createMisina({
+    const api = createMisina({
       driver,
       retry: 0,
       hooks: {
@@ -34,15 +34,16 @@ describe("withRefreshOn401 — race + recursion (Bug 47)", () => {
           return new Request(ctx.request, { headers })
         },
       },
-    })
-
-    const api = withRefreshOn401(misina, {
-      refresh: async () => {
-        refreshCount++
-        await new Promise((r) => setTimeout(r, 10))
-        token = "new"
-        return token
-      },
+      use: [
+        refreshOn401({
+          refresh: async () => {
+            refreshCount++
+            await new Promise((r) => setTimeout(r, 10))
+            token = "new"
+            return token
+          },
+        }),
+      ],
     })
 
     await Promise.all([
@@ -65,9 +66,11 @@ describe("withRefreshOn401 — race + recursion (Bug 47)", () => {
       },
     }
 
-    const misina = createMisina({ driver, retry: 0, throwHttpErrors: false })
-    const api = withRefreshOn401(misina, {
-      refresh: async () => "new-but-still-bad",
+    const api = createMisina({
+      driver,
+      retry: 0,
+      throwHttpErrors: false,
+      use: [refreshOn401({ refresh: async () => "new-but-still-bad" })],
     })
 
     const res = await api.get("https://api.test/x")
@@ -87,8 +90,12 @@ describe("withRefreshOn401 — race + recursion (Bug 47)", () => {
       },
     }
 
-    const misina = createMisina({ driver, retry: 0, throwHttpErrors: false })
-    const api = withRefreshOn401(misina, { refresh: async () => "new" })
+    const api = createMisina({
+      driver,
+      retry: 0,
+      throwHttpErrors: false,
+      use: [refreshOn401({ refresh: async () => "new" })],
+    })
 
     await api.get("https://api.test/x")
     expect(sawMarker).toBe(false)

--- a/test/auth-signed.test.ts
+++ b/test/auth-signed.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
-import { signRequest, withMessageSignature } from "../src/auth/signed.ts"
+import { messageSignature, signRequest } from "../src/auth/signed.ts"
 
 function parseSignatureInput(header: string): {
   label: string
@@ -38,7 +38,7 @@ function decodeBase64(b64: string): Uint8Array {
   return out
 }
 
-describe("withMessageSignature — HMAC-SHA256 (shared secret)", () => {
+describe("messageSignature — HMAC-SHA256 (shared secret)", () => {
   it("signs a request with hmac-sha256 and verifies via crypto.subtle", async () => {
     const secret = new TextEncoder().encode("super-secret")
     let captured: Headers | undefined
@@ -49,12 +49,18 @@ describe("withMessageSignature — HMAC-SHA256 (shared secret)", () => {
         return new Response("ok", { status: 200 })
       },
     }
-    const m = withMessageSignature(createMisina({ driver, retry: 0 }), {
-      keyId: "test-key",
-      algorithm: "hmac-sha256",
-      privateKey: secret,
-      components: ["@method", "@target-uri"],
-      created: 1_700_000_000,
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        messageSignature({
+          keyId: "test-key",
+          algorithm: "hmac-sha256",
+          privateKey: secret,
+          components: ["@method", "@target-uri"],
+          created: 1_700_000_000,
+        }),
+      ],
     })
     await m.get("https://example.com/foo")
     expect(captured?.get("signature-input")).toBeTruthy()
@@ -103,15 +109,21 @@ describe("withMessageSignature — HMAC-SHA256 (shared secret)", () => {
         return new Response("ok", { status: 200 })
       },
     }
-    const m = withMessageSignature(createMisina({ driver, retry: 0 }), {
-      keyId: "k",
-      algorithm: "hmac-sha256",
-      privateKey: secret,
-      components: ["@method"],
-      created: 1_700_000_000,
-      expires: 1_700_000_900,
-      nonce: "abc123",
-      tag: "audit",
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        messageSignature({
+          keyId: "k",
+          algorithm: "hmac-sha256",
+          privateKey: secret,
+          components: ["@method"],
+          created: 1_700_000_000,
+          expires: 1_700_000_900,
+          nonce: "abc123",
+          tag: "audit",
+        }),
+      ],
     })
     await m.get("https://example.com/")
     const input = parseSignatureInput(captured!.get("signature-input")!)
@@ -130,11 +142,17 @@ describe("withMessageSignature — HMAC-SHA256 (shared secret)", () => {
         return new Response("ok", { status: 200 })
       },
     }
-    const m = withMessageSignature(createMisina({ driver, retry: 0 }), {
-      algorithm: "hmac-sha256",
-      privateKey: secret,
-      components: ["@method"],
-      label: "audit-sig",
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        messageSignature({
+          algorithm: "hmac-sha256",
+          privateKey: secret,
+          components: ["@method"],
+          label: "audit-sig",
+        }),
+      ],
     })
     await m.get("https://example.com/")
     expect(captured?.get("signature-input")).toMatch(/^audit-sig=\(/)
@@ -142,7 +160,7 @@ describe("withMessageSignature — HMAC-SHA256 (shared secret)", () => {
   })
 })
 
-describe("withMessageSignature — Ed25519 (Web Crypto, asymmetric)", () => {
+describe("messageSignature — Ed25519 (Web Crypto, asymmetric)", () => {
   it("signs and verifies with a generated Ed25519 keypair", async () => {
     let pair: CryptoKeyPair
     try {
@@ -164,12 +182,18 @@ describe("withMessageSignature — Ed25519 (Web Crypto, asymmetric)", () => {
         return new Response("ok", { status: 200 })
       },
     }
-    const m = withMessageSignature(createMisina({ driver, retry: 0 }), {
-      keyId: "ed1",
-      algorithm: "ed25519",
-      privateKey: pair.privateKey,
-      components: ["@method", "@target-uri"],
-      created: 1_700_000_000,
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        messageSignature({
+          keyId: "ed1",
+          algorithm: "ed25519",
+          privateKey: pair.privateKey,
+          components: ["@method", "@target-uri"],
+          created: 1_700_000_000,
+        }),
+      ],
     })
     await m.get("https://example.com/foo")
 

--- a/test/auth-sigv4.test.ts
+++ b/test/auth-sigv4.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
-import { signRequest, withSigV4 } from "../src/auth/sigv4.ts"
+import { sigv4, signRequest } from "../src/auth/sigv4.ts"
 
 // AWS Signature V4 test suite: `get-vanilla`.
 // https://github.com/awsdocs/aws-doc-sdk-examples/tree/main/aws-sig-v4-test-suite
@@ -114,7 +114,7 @@ describe("signRequest — AWS test vectors", () => {
   })
 })
 
-describe("withSigV4 hook", () => {
+describe("sigv4 hook", () => {
   it("attaches Authorization to outgoing requests via beforeRequest", async () => {
     let capturedAuth: string | null = null
     const driver = {
@@ -124,10 +124,16 @@ describe("withSigV4 hook", () => {
         return new Response("ok", { status: 200 })
       },
     }
-    const m = withSigV4(createMisina({ driver, retry: 0 }), {
-      service: "bedrock-runtime",
-      region: "us-east-1",
-      credentials: TEST_CREDENTIALS,
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        sigv4({
+          service: "bedrock-runtime",
+          region: "us-east-1",
+          credentials: TEST_CREDENTIALS,
+        }),
+      ],
     })
     await m.get("https://bedrock-runtime.us-east-1.amazonaws.com/foo")
     expect(capturedAuth).toMatch(/^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/)
@@ -144,13 +150,19 @@ describe("withSigV4 hook", () => {
         return new Response("ok", { status: 200 })
       },
     }
-    const m = withSigV4(createMisina({ driver, retry: 0 }), {
-      service: "service",
-      region: "us-east-1",
-      credentials: async () => {
-        provides++
-        return { accessKeyId: `AKIA${provides}`, secretAccessKey: "secret" }
-      },
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        sigv4({
+          service: "service",
+          region: "us-east-1",
+          credentials: async () => {
+            provides++
+            return { accessKeyId: `AKIA${provides}`, secretAccessKey: "secret" }
+          },
+        }),
+      ],
     })
     await m.get("https://example.amazonaws.com/")
     await m.get("https://example.amazonaws.com/")

--- a/test/breaker.test.ts
+++ b/test/breaker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
-import { CircuitOpenError, withCircuitBreaker } from "../src/breaker/index.ts"
+import { breaker, CircuitOpenError } from "../src/breaker/index.ts"
 
 function alwaysFailingDriver(status = 500) {
   return {
@@ -16,9 +16,9 @@ function okDriver() {
   }
 }
 
-describe("withCircuitBreaker — state machine", () => {
+describe("breaker — state machine", () => {
   it("starts closed and lets requests through", async () => {
-    const m = withCircuitBreaker(createMisina({ driver: okDriver(), retry: 0 }))
+    const m = createMisina({ driver: okDriver(), retry: 0, use: [breaker()] })
     expect(m.breaker.state()).toBe("closed")
 
     await m.get("https://api.test/")
@@ -26,9 +26,10 @@ describe("withCircuitBreaker — state machine", () => {
   })
 
   it("trips after failureThreshold consecutive 500s", async () => {
-    const m = withCircuitBreaker(createMisina({ driver: alwaysFailingDriver(500), retry: 0 }), {
-      failureThreshold: 3,
-      halfOpenAfter: 50,
+    const m = createMisina({
+      driver: alwaysFailingDriver(500),
+      retry: 0,
+      use: [breaker({ failureThreshold: 3, halfOpenAfter: 50 })],
     })
 
     for (let i = 0; i < 3; i++) {
@@ -38,9 +39,10 @@ describe("withCircuitBreaker — state machine", () => {
   })
 
   it("rejects fast with CircuitOpenError once open", async () => {
-    const m = withCircuitBreaker(createMisina({ driver: alwaysFailingDriver(500), retry: 0 }), {
-      failureThreshold: 2,
-      halfOpenAfter: 50,
+    const m = createMisina({
+      driver: alwaysFailingDriver(500),
+      retry: 0,
+      use: [breaker({ failureThreshold: 2, halfOpenAfter: 50 })],
     })
 
     await m.get("https://api.test/").catch(() => {})
@@ -51,8 +53,10 @@ describe("withCircuitBreaker — state machine", () => {
   })
 
   it("does NOT count 4xx as a failure (client error)", async () => {
-    const m = withCircuitBreaker(createMisina({ driver: alwaysFailingDriver(404), retry: 0 }), {
-      failureThreshold: 2,
+    const m = createMisina({
+      driver: alwaysFailingDriver(404),
+      retry: 0,
+      use: [breaker({ failureThreshold: 2 })],
     })
 
     for (let i = 0; i < 5; i++) {
@@ -71,9 +75,10 @@ describe("withCircuitBreaker — state machine", () => {
         return new Response("{}", { headers: { "content-type": "application/json" } })
       },
     }
-    const m = withCircuitBreaker(createMisina({ driver, retry: 0 }), {
-      failureThreshold: 2,
-      halfOpenAfter: 30,
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [breaker({ failureThreshold: 2, halfOpenAfter: 30 })],
     })
 
     await m.get("https://api.test/").catch(() => {})
@@ -89,9 +94,10 @@ describe("withCircuitBreaker — state machine", () => {
   })
 
   it("probe failure puts breaker back to open with fresh timer", async () => {
-    const m = withCircuitBreaker(createMisina({ driver: alwaysFailingDriver(500), retry: 0 }), {
-      failureThreshold: 2,
-      halfOpenAfter: 30,
+    const m = createMisina({
+      driver: alwaysFailingDriver(500),
+      retry: 0,
+      use: [breaker({ failureThreshold: 2, halfOpenAfter: 30 })],
     })
 
     await m.get("https://api.test/").catch(() => {})
@@ -106,8 +112,10 @@ describe("withCircuitBreaker — state machine", () => {
   })
 
   it(".breaker.trip() forces open immediately", async () => {
-    const m = withCircuitBreaker(createMisina({ driver: okDriver(), retry: 0 }), {
-      halfOpenAfter: 50,
+    const m = createMisina({
+      driver: okDriver(),
+      retry: 0,
+      use: [breaker({ halfOpenAfter: 50 })],
     })
     expect(m.breaker.state()).toBe("closed")
     m.breaker.trip()
@@ -116,7 +124,7 @@ describe("withCircuitBreaker — state machine", () => {
   })
 
   it(".breaker.reset() forces back to closed", async () => {
-    const m = withCircuitBreaker(createMisina({ driver: okDriver(), retry: 0 }))
+    const m = createMisina({ driver: okDriver(), retry: 0, use: [breaker()] })
     m.breaker.trip()
     expect(m.breaker.state()).toBe("open")
     m.breaker.reset()
@@ -127,20 +135,28 @@ describe("withCircuitBreaker — state machine", () => {
   })
 
   it("CircuitOpenError carries retryAfter ms", async () => {
-    const m = withCircuitBreaker(createMisina({ driver: okDriver(), retry: 0 }), {
-      halfOpenAfter: 1000,
+    const m = createMisina({
+      driver: okDriver(),
+      retry: 0,
+      use: [breaker({ halfOpenAfter: 1000 })],
     })
     m.breaker.trip()
-    const err = (await m.get("https://api.test/").catch((e) => e)) as CircuitOpenError
+    const err = (await m.get("https://api.test/").catch((e: unknown) => e)) as CircuitOpenError
     expect(err).toBeInstanceOf(CircuitOpenError)
     expect(err.retryAfter).toBeGreaterThan(0)
     expect(err.retryAfter).toBeLessThanOrEqual(1000)
   })
 
   it("custom isFailure overrides the 5xx-only default", async () => {
-    const m = withCircuitBreaker(createMisina({ driver: alwaysFailingDriver(404), retry: 0 }), {
-      failureThreshold: 2,
-      isFailure: ({ error }) => error != null, // count any error as failure
+    const m = createMisina({
+      driver: alwaysFailingDriver(404),
+      retry: 0,
+      use: [
+        breaker({
+          failureThreshold: 2,
+          isFailure: ({ error }: { error: Error | undefined }) => error != null,
+        }),
+      ],
     })
 
     await m.get("https://api.test/").catch(() => {})
@@ -155,8 +171,10 @@ describe("withCircuitBreaker — state machine", () => {
         throw Object.assign(new TypeError("fetch failed"), { name: "TypeError" })
       },
     }
-    const m = withCircuitBreaker(createMisina({ driver, retry: 0 }), {
-      failureThreshold: 2,
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [breaker({ failureThreshold: 2 })],
     })
 
     await m.get("https://api.test/").catch(() => {})

--- a/test/cache-extensions.test.ts
+++ b/test/cache-extensions.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
-import { memoryStore, withCache } from "../src/cache/index.ts"
+import type { CacheEntry } from "../src/cache/index.ts"
+import { cache, memoryStore } from "../src/cache/index.ts"
+import type { MisinaContext } from "../src/types.ts"
 
 function jsonResponse(body: unknown, headers: Record<string, string> = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -8,7 +10,7 @@ function jsonResponse(body: unknown, headers: Record<string, string> = {}): Resp
   })
 }
 
-describe("withCache — shouldStore filter", () => {
+describe("cache — shouldStore filter", () => {
   it("rejects responses that fail the predicate", async () => {
     const store = memoryStore()
     let calls = 0
@@ -19,12 +21,18 @@ describe("withCache — shouldStore filter", () => {
         return jsonResponse({ ok: true })
       },
     }
-    const m = withCache(createMisina({ driver, retry: 0 }), {
-      store,
-      shouldStore: (_req, res) => {
-        // Refuse to cache anything (simulate a strict policy).
-        return res.headers.get("x-cache") === "ok"
-      },
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        cache({
+          store,
+          shouldStore: (_req: Request, res: Response) => {
+            // Refuse to cache anything (simulate a strict policy).
+            return res.headers.get("x-cache") === "ok"
+          },
+        }),
+      ],
     })
 
     await m.get("https://api.test/")
@@ -42,9 +50,10 @@ describe("withCache — shouldStore filter", () => {
         return jsonResponse({ ok: true }, { "cache-control": "max-age=60" })
       },
     }
-    const m = withCache(createMisina({ driver, retry: 0 }), {
-      store,
-      shouldStore: () => true,
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [cache({ store, shouldStore: () => true })],
     })
 
     await m.get("https://api.test/")
@@ -53,7 +62,7 @@ describe("withCache — shouldStore filter", () => {
   })
 })
 
-describe("withCache — beforeStore mutator", () => {
+describe("cache — beforeStore mutator", () => {
   it("can replace the entry", async () => {
     const store = memoryStore()
     const driver = {
@@ -61,13 +70,19 @@ describe("withCache — beforeStore mutator", () => {
       request: async () =>
         jsonResponse({ secret: "abc", visible: 1 }, { "cache-control": "max-age=60" }),
     }
-    const m = withCache(createMisina({ driver, retry: 0 }), {
-      store,
-      beforeStore: (entry) => ({
-        ...entry,
-        // tag the entry with custom metadata
-        vary: { ...(entry.vary ?? {}), "x-source": "filtered" },
-      }),
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        cache({
+          store,
+          beforeStore: (entry: CacheEntry) => ({
+            ...entry,
+            // tag the entry with custom metadata
+            vary: { ...(entry.vary ?? {}), "x-source": "filtered" },
+          }),
+        }),
+      ],
     })
 
     await m.get("https://api.test/")
@@ -88,9 +103,10 @@ describe("withCache — beforeStore mutator", () => {
         return jsonResponse({ ok: true }, { "cache-control": "max-age=60" })
       },
     }
-    const m = withCache(createMisina({ driver, retry: 0 }), {
-      store,
-      beforeStore: () => undefined,
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [cache({ store, beforeStore: () => undefined })],
     })
 
     await m.get("https://api.test/")
@@ -99,7 +115,7 @@ describe("withCache — beforeStore mutator", () => {
   })
 })
 
-describe("withCache — custom key with meta", () => {
+describe("cache — custom key with meta", () => {
   it("custom key partitions cache by user (verifies key callback works as documented)", async () => {
     const store = memoryStore()
     let calls = 0
@@ -110,12 +126,18 @@ describe("withCache — custom key with meta", () => {
         return jsonResponse({ ok: true }, { "cache-control": "max-age=60" })
       },
     }
-    const m = withCache(createMisina({ driver, retry: 0 }), {
-      store,
-      key: (ctx) => {
-        const userId = (ctx.options.headers as Record<string, string>)?.["x-user-id"] ?? "anon"
-        return `${ctx.options.method} ${ctx.options.url}|user=${userId}`
-      },
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        cache({
+          store,
+          key: (ctx: MisinaContext) => {
+            const userId = (ctx.options.headers as Record<string, string>)?.["x-user-id"] ?? "anon"
+            return `${ctx.options.method} ${ctx.options.url}|user=${userId}`
+          },
+        }),
+      ],
     })
 
     await m.get("https://api.test/profile", { headers: { "x-user-id": "u1" } })

--- a/test/cache-rfc.test.ts
+++ b/test/cache-rfc.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
-import { withCache, memoryStore } from "../src/cache/index.ts"
+import { cache, memoryStore } from "../src/cache/index.ts"
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -9,7 +9,7 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   })
 }
 
-describe("withCache — RFC 9111 compliance", () => {
+describe("cache — RFC 9111 compliance", () => {
   it("Cache-Control: no-store is honored (response not stored)", async () => {
     let calls = 0
     const driver = {
@@ -26,7 +26,7 @@ describe("withCache — RFC 9111 compliance", () => {
     }
 
     const store = memoryStore()
-    const m = withCache(createMisina({ driver, retry: 0 }), { store, ttl: 60_000 })
+    const m = createMisina({ driver, retry: 0, use: [cache({ store, ttl: 60_000 })] })
 
     await m.get("https://api.test/")
     await m.get("https://api.test/")
@@ -55,7 +55,7 @@ describe("withCache — RFC 9111 compliance", () => {
     }
 
     const store = memoryStore()
-    const m = withCache(createMisina({ driver, retry: 0 }), { store, ttl: 60_000 })
+    const m = createMisina({ driver, retry: 0, use: [cache({ store, ttl: 60_000 })] })
 
     await m.get("https://api.test/")
     expect(calls).toBe(1)
@@ -86,7 +86,7 @@ describe("withCache — RFC 9111 compliance", () => {
     }
 
     const store = memoryStore()
-    const m = withCache(createMisina({ driver, retry: 0 }), { store, ttl: 60_000 })
+    const m = createMisina({ driver, retry: 0, use: [cache({ store, ttl: 60_000 })] })
 
     const en = await m.get<{ lang: string }>("https://api.test/", {
       headers: { "accept-language": "en" },
@@ -127,7 +127,7 @@ describe("withCache — RFC 9111 compliance", () => {
     }
 
     const store = memoryStore()
-    const m = withCache(createMisina({ driver, retry: 0 }), { store, ttl: 60_000 })
+    const m = createMisina({ driver, retry: 0, use: [cache({ store, ttl: 60_000 })] })
 
     await m.get("https://api.test/")
     await m.get("https://api.test/")

--- a/test/cache-rfc5861.test.ts
+++ b/test/cache-rfc5861.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
-import { memoryStore, parseCacheControl, withCache } from "../src/cache/index.ts"
+import { cache, memoryStore, parseCacheControl } from "../src/cache/index.ts"
 
 describe("parseCacheControl", () => {
   it("parses common directives", () => {
@@ -33,7 +33,7 @@ describe("parseCacheControl", () => {
   })
 })
 
-describe("withCache — RFC 5861 stale-while-revalidate", () => {
+describe("cache — RFC 5861 stale-while-revalidate", () => {
   it("serves stale entry within SWR window and revalidates in background", async () => {
     const store = memoryStore()
     let serverHits = 0
@@ -50,7 +50,7 @@ describe("withCache — RFC 5861 stale-while-revalidate", () => {
         })
       },
     }
-    const m = withCache(createMisina({ driver, retry: 0 }), { store, ttl: 0 })
+    const m = createMisina({ driver, retry: 0, use: [cache({ store, ttl: 0 })] })
     // Prime the cache.
     await m.get("https://x.test/")
     expect(serverHits).toBe(1)
@@ -85,7 +85,7 @@ describe("withCache — RFC 5861 stale-while-revalidate", () => {
   })
 })
 
-describe("withCache — RFC 5861 stale-if-error", () => {
+describe("cache — RFC 5861 stale-if-error", () => {
   it("serves cached entry when origin returns 5xx within SIE window", async () => {
     const store = memoryStore()
     let firstCall = true
@@ -105,7 +105,7 @@ describe("withCache — RFC 5861 stale-if-error", () => {
         return new Response("boom", { status: 503 })
       },
     }
-    const m = withCache(createMisina({ driver, retry: 0 }), { store, ttl: 0 })
+    const m = createMisina({ driver, retry: 0, use: [cache({ store, ttl: 0 })] })
     await m.get("https://x.test/")
     await new Promise((r) => setTimeout(r, 5))
 
@@ -133,7 +133,7 @@ describe("withCache — RFC 5861 stale-if-error", () => {
         return new Response("nope", { status: 404 })
       },
     }
-    const m = withCache(createMisina({ driver, retry: 0 }), { store, ttl: 0 })
+    const m = createMisina({ driver, retry: 0, use: [cache({ store, ttl: 0 })] })
     await m.get("https://x.test/")
     await new Promise((r) => setTimeout(r, 5))
 
@@ -141,7 +141,7 @@ describe("withCache — RFC 5861 stale-if-error", () => {
   })
 })
 
-describe("withCache — RFC 8246 immutable", () => {
+describe("cache — RFC 8246 immutable", () => {
   it("skips conditional revalidation when entry is immutable", async () => {
     const store = memoryStore()
     let calls = 0
@@ -164,7 +164,7 @@ describe("withCache — RFC 8246 immutable", () => {
         })
       },
     }
-    const m = withCache(createMisina({ driver, retry: 0 }), { store, ttl: 0 })
+    const m = createMisina({ driver, retry: 0, use: [cache({ store, ttl: 0 })] })
     await m.get("https://x.test/")
     await new Promise((r) => setTimeout(r, 5))
 

--- a/test/cookie-integration.test.ts
+++ b/test/cookie-integration.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
-import { MemoryCookieJar, withCookieJar } from "../src/cookie/index.ts"
+import { cookieJar, MemoryCookieJar } from "../src/cookie/index.ts"
 
-describe("withCookieJar — integration with misina lifecycle", () => {
+describe("cookieJar — integration with misina lifecycle", () => {
   it("captures multiple Set-Cookie headers via getSetCookie", async () => {
     const driver = {
       name: "multi-set-cookie",
@@ -22,7 +22,7 @@ describe("withCookieJar — integration with misina lifecycle", () => {
     }
 
     const jar = new MemoryCookieJar()
-    const m = withCookieJar(createMisina({ driver, retry: 0 }), jar)
+    const m = createMisina({ driver, retry: 0, use: [cookieJar(jar)] })
 
     await m.get("https://api.test/login")
     const res = await m.get<{ cookie: string }>("https://api.test/profile")
@@ -50,7 +50,7 @@ describe("withCookieJar — integration with misina lifecycle", () => {
     }
 
     const jar = new MemoryCookieJar()
-    const m = withCookieJar(createMisina({ driver, retry: 0 }), jar)
+    const m = createMisina({ driver, retry: 0, use: [cookieJar(jar)] })
 
     await m.get("https://api.test/set")
     const res = await m.get<{ cookie: string }>("https://api.test/check")
@@ -74,7 +74,7 @@ describe("withCookieJar — integration with misina lifecycle", () => {
     }
 
     const jar = new MemoryCookieJar()
-    const m = withCookieJar(createMisina({ driver, retry: 0 }), jar)
+    const m = createMisina({ driver, retry: 0, use: [cookieJar(jar)] })
 
     await m.get("https://api.test/login")
     const same = await m.get<{ cookie: string }>("https://api.test/x")
@@ -100,7 +100,7 @@ describe("withCookieJar — integration with misina lifecycle", () => {
     }
 
     const jar = new MemoryCookieJar()
-    const m = withCookieJar(createMisina({ driver, retry: 0 }), jar)
+    const m = createMisina({ driver, retry: 0, use: [cookieJar(jar)] })
 
     await m.get("https://api.test/login")
     await m.get("https://api.test/x", { headers: { cookie: "from-user=B" } })
@@ -128,7 +128,7 @@ describe("withCookieJar — integration with misina lifecycle", () => {
     }
 
     const jar = new MemoryCookieJar()
-    const m = withCookieJar(createMisina({ driver, retry: 0 }), jar)
+    const m = createMisina({ driver, retry: 0, use: [cookieJar(jar)] })
 
     await m.get("https://api.test/api/login")
     await m.get("https://api.test/other/page")

--- a/test/cookie-redirects.test.ts
+++ b/test/cookie-redirects.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
-import { MemoryCookieJar, withCookieJar } from "../src/cookie/index.ts"
+import { cookieJar, MemoryCookieJar } from "../src/cookie/index.ts"
 
-describe("withCookieJar — redirect persistence (undici #3784 parity)", () => {
+describe("cookieJar — redirect persistence (undici #3784 parity)", () => {
   it("captures Set-Cookie issued by an intermediate redirect hop", async () => {
     const jar = new MemoryCookieJar()
     let call = 0
@@ -29,7 +29,7 @@ describe("withCookieJar — redirect persistence (undici #3784 parity)", () => {
         })
       },
     }
-    const m = withCookieJar(createMisina({ driver, retry: 0 }), jar)
+    const m = createMisina({ driver, retry: 0, use: [cookieJar(jar)] })
     const result = await m.get<{ cookie: string }>("https://api.test/login")
     expect(result.data.cookie).toBe("session=abc123")
     // Jar persisted the cookie from the intermediate hop.
@@ -68,7 +68,7 @@ describe("withCookieJar — redirect persistence (undici #3784 parity)", () => {
         })
       },
     }
-    const m = withCookieJar(createMisina({ driver, retry: 0 }), jar)
+    const m = createMisina({ driver, retry: 0, use: [cookieJar(jar)] })
     const result = await m.get<{ cookie: string }>("https://api.test/one")
     // Both cookies sent on the third hop.
     expect(result.data.cookie).toContain("a=1")
@@ -85,7 +85,7 @@ describe("withCookieJar — redirect persistence (undici #3784 parity)", () => {
           headers: { "set-cookie": "session=zzz; Path=/" },
         }),
     }
-    const m = withCookieJar(createMisina({ driver, retry: 0 }), jar)
+    const m = createMisina({ driver, retry: 0, use: [cookieJar(jar)] })
     await m.get("https://api.test/")
     expect(await jar.getCookieString("https://api.test/")).toBe("session=zzz")
   })

--- a/test/dedupe-edges.test.ts
+++ b/test/dedupe-edges.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { createMisina, HTTPError } from "../src/index.ts"
-import { withDedupe } from "../src/dedupe/index.ts"
+import { dedupe } from "../src/dedupe/index.ts"
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -9,7 +9,7 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   })
 }
 
-describe("withDedupe — additional edges", () => {
+describe("dedupe — additional edges", () => {
   it("all concurrent waiters receive the same parsed data", async () => {
     let calls = 0
     const driver = {
@@ -19,7 +19,7 @@ describe("withDedupe — additional edges", () => {
         return jsonResponse({ id: calls })
       },
     }
-    const m = withDedupe(createMisina({ driver, retry: 0 }))
+    const m = createMisina({ driver, retry: 0, use: [dedupe()] })
     const [a, b, c] = await Promise.all([
       m.get<{ id: number }>("https://api.test/x"),
       m.get<{ id: number }>("https://api.test/x"),
@@ -39,7 +39,7 @@ describe("withDedupe — additional edges", () => {
         return jsonResponse({ message: "fail" }, { status: 500 })
       },
     }
-    const m = withDedupe(createMisina({ driver, retry: 0 }))
+    const m = createMisina({ driver, retry: 0, use: [dedupe()] })
 
     const settled = await Promise.allSettled([
       m.get("https://api.test/x"),
@@ -64,7 +64,7 @@ describe("withDedupe — additional edges", () => {
         return jsonResponse({ ok: true })
       },
     }
-    const m = withDedupe(createMisina({ driver, retry: 0 }))
+    const m = createMisina({ driver, retry: 0, use: [dedupe()] })
 
     await Promise.all([m.get("https://api.test/a"), m.get("https://api.test/b")])
     expect(calls).toBe(2)
@@ -79,7 +79,7 @@ describe("withDedupe — additional edges", () => {
         return jsonResponse({ id: calls })
       },
     }
-    const m = withDedupe(createMisina({ driver, retry: 0 }))
+    const m = createMisina({ driver, retry: 0, use: [dedupe()] })
 
     const a = await m.get<{ id: number }>("https://api.test/x")
     const b = await m.get<{ id: number }>("https://api.test/x")
@@ -97,7 +97,7 @@ describe("withDedupe — additional edges", () => {
         return jsonResponse({ ok: true })
       },
     }
-    const m = withDedupe(createMisina({ driver, retry: 0 }))
+    const m = createMisina({ driver, retry: 0, use: [dedupe()] })
 
     await Promise.all([
       m.post("https://api.test/x", { a: 1 }),
@@ -115,7 +115,7 @@ describe("withDedupe — additional edges", () => {
         return jsonResponse({ ok: true })
       },
     }
-    const m = withDedupe(createMisina({ driver, retry: 0 }), { methods: ["POST"] })
+    const m = createMisina({ driver, retry: 0, use: [dedupe({ methods: ["POST"] })] })
 
     await Promise.all([
       m.post("https://api.test/x", { a: 1 }),
@@ -133,13 +133,19 @@ describe("withDedupe — additional edges", () => {
         return jsonResponse({ ok: true })
       },
     }
-    const m = withDedupe(createMisina({ driver, retry: 0 }), {
-      // Custom key: ignore query order/casing.
-      key: (input) => {
-        const u = new URL(input)
-        const sortedParams = [...u.searchParams.entries()].sort()
-        return `${u.origin}${u.pathname}?${sortedParams.map(([k, v]) => `${k}=${v}`).join("&")}`
-      },
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        dedupe({
+          // Custom key: ignore query order/casing.
+          key: (input: string) => {
+            const u = new URL(input)
+            const sortedParams = [...u.searchParams.entries()].sort()
+            return `${u.origin}${u.pathname}?${sortedParams.map(([k, v]) => `${k}=${v}`).join("&")}`
+          },
+        }),
+      ],
     })
 
     await Promise.all([m.get("https://api.test/q?a=1&b=2"), m.get("https://api.test/q?b=2&a=1")])
@@ -155,7 +161,7 @@ describe("withDedupe — additional edges", () => {
         return jsonResponse({ ok: true })
       },
     }
-    const m = withDedupe(createMisina({ driver, retry: 0 }))
+    const m = createMisina({ driver, retry: 0, use: [dedupe()] })
 
     await Promise.all([
       m.put("https://api.test/x", { a: 1 }),
@@ -169,7 +175,7 @@ describe("withDedupe — additional edges", () => {
       name: "f",
       request: async () => jsonResponse({ ok: true }),
     }
-    const m = withDedupe(createMisina({ driver, retry: 0 }))
+    const m = createMisina({ driver, retry: 0, use: [dedupe()] })
 
     const [a, b] = await Promise.all([m.get("https://api.test/x"), m.get("https://api.test/x")])
     // Both waiters share the same response object — they get the parsed data

--- a/test/dedupe.test.ts
+++ b/test/dedupe.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
 import mockDriverFactory from "../src/driver/mock.ts"
-import { withDedupe } from "../src/dedupe/index.ts"
+import { dedupe } from "../src/dedupe/index.ts"
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -10,7 +10,7 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   })
 }
 
-describe("withDedupe", () => {
+describe("dedupe", () => {
   it("collapses concurrent identical GETs onto a single network call", async () => {
     let calls = 0
     const driver = {
@@ -22,7 +22,7 @@ describe("withDedupe", () => {
       },
     }
 
-    const api = withDedupe(createMisina({ driver, retry: 0 }))
+    const api = createMisina({ driver, retry: 0, use: [dedupe()] })
 
     const [a, b, c] = await Promise.all([
       api.get("https://api.test/x"),
@@ -46,7 +46,7 @@ describe("withDedupe", () => {
       },
     }
 
-    const api = withDedupe(createMisina({ driver, retry: 0 }))
+    const api = createMisina({ driver, retry: 0, use: [dedupe()] })
 
     await Promise.all([
       api.post("https://api.test/x", { a: 1 }),
@@ -60,7 +60,7 @@ describe("withDedupe", () => {
     const driver = mockDriverFactory({
       response: new Response("nope", { status: 404 }),
     })
-    const api = withDedupe(createMisina({ driver, retry: 0 }))
+    const api = createMisina({ driver, retry: 0, use: [dedupe()] })
 
     const result = await api.get<unknown>("https://api.test/").onError(404, () => "fallback")
     expect(result).toBe("fallback")
@@ -79,9 +79,16 @@ describe("withDedupe", () => {
       },
     }
 
-    const api = withDedupe(createMisina({ driver, retry: 0 }), {
-      methods: ["POST"],
-      key: (input, init) => `${init?.method ?? "GET"} ${input} ${JSON.stringify(init?.body ?? {})}`,
+    const api = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        dedupe({
+          methods: ["POST"],
+          key: (input: string, init?: { method?: string; body?: unknown }) =>
+            `${init?.method ?? "GET"} ${input} ${JSON.stringify(init?.body ?? {})}`,
+        }),
+      ],
     })
 
     await Promise.all([

--- a/test/digest.test.ts
+++ b/test/digest.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
-import { DigestMismatchError, verifyDigest, withDigest } from "../src/digest/index.ts"
+import { digestAuth, DigestMismatchError, verifyDigest } from "../src/digest/index.ts"
 
 // RFC 9530 §6 example: sha-256 of `{"hello": "world"}` (with the
 // space) is X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=
 const RFC9530_BODY = '{"hello": "world"}'
 const RFC9530_SHA256 = "X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
 
-describe("withDigest — outgoing", () => {
+describe("digestAuth — outgoing", () => {
   it("adds Content-Digest with the RFC 9530 §6 sha-256 vector", async () => {
     let captured: Headers | undefined
     const driver = {
@@ -17,7 +17,7 @@ describe("withDigest — outgoing", () => {
         return new Response("ok", { status: 200 })
       },
     }
-    const m = withDigest(createMisina({ driver, retry: 0 }))
+    const m = createMisina({ driver, retry: 0, use: [digestAuth()] })
     await m.post("https://x.test/", RFC9530_BODY, {
       headers: { "content-type": "application/json" },
     })
@@ -33,7 +33,7 @@ describe("withDigest — outgoing", () => {
         return new Response("ok", { status: 200 })
       },
     }
-    const m = withDigest(createMisina({ driver, retry: 0 }), { field: "repr-digest" })
+    const m = createMisina({ driver, retry: 0, use: [digestAuth({ field: "repr-digest" })] })
     await m.post("https://x.test/", RFC9530_BODY, {
       headers: { "content-type": "application/json" },
     })
@@ -50,7 +50,7 @@ describe("withDigest — outgoing", () => {
         return new Response("ok", { status: 200 })
       },
     }
-    const m = withDigest(createMisina({ driver, retry: 0 }), { algorithm: "sha-512" })
+    const m = createMisina({ driver, retry: 0, use: [digestAuth({ algorithm: "sha-512" })] })
     await m.post("https://x.test/", RFC9530_BODY)
     const v = captured?.get("content-digest")
     expect(v).toMatch(/^sha-512=:[A-Za-z0-9+/=]+:$/)
@@ -65,7 +65,7 @@ describe("withDigest — outgoing", () => {
         return new Response("ok", { status: 200 })
       },
     }
-    const m = withDigest(createMisina({ driver, retry: 0 }))
+    const m = createMisina({ driver, retry: 0, use: [digestAuth()] })
     await m.get("https://x.test/")
     expect(captured?.get("content-digest")).toBeNull()
   })
@@ -79,7 +79,7 @@ describe("withDigest — outgoing", () => {
         return new Response("ok", { status: 200 })
       },
     }
-    const m = withDigest(createMisina({ driver, retry: 0 }))
+    const m = createMisina({ driver, retry: 0, use: [digestAuth()] })
     await m.post("https://x.test/", RFC9530_BODY, {
       headers: { "content-type": "application/json" },
     })
@@ -95,7 +95,7 @@ describe("withDigest — outgoing", () => {
         return new Response("ok", { status: 200 })
       },
     }
-    const m = withDigest(createMisina({ driver, retry: 0 }))
+    const m = createMisina({ driver, retry: 0, use: [digestAuth()] })
     await m.post("https://x.test/", RFC9530_BODY, {
       headers: { "content-digest": "md5=:abc:" },
     })

--- a/test/features.test.ts
+++ b/test/features.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
 import mockDriverFactory, { getMockApi } from "../src/driver/mock.ts"
-import { withCookieJar, MemoryCookieJar } from "../src/cookie/index.ts"
-import { withBearer, withBasic } from "../src/auth/index.ts"
+import { cookieJar, MemoryCookieJar } from "../src/cookie/index.ts"
+import { basic, bearer } from "../src/auth/index.ts"
 import { paginateAll } from "../src/paginate/index.ts"
-import { withCache, memoryStore } from "../src/cache/index.ts"
+import { cache, memoryStore } from "../src/cache/index.ts"
 import { sseStream, ndjsonStream } from "../src/stream/index.ts"
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
@@ -90,7 +90,7 @@ describe("cookie jar (#21)", () => {
     })
 
     const jar = new MemoryCookieJar()
-    const m = withCookieJar(createMisina({ driver, retry: 0 }), jar)
+    const m = createMisina({ driver, retry: 0, use: [cookieJar(jar)] })
 
     await m.get("https://api.test/login")
     const res = await m.get<{ cookie: string }>("https://api.test/profile")
@@ -100,25 +100,25 @@ describe("cookie jar (#21)", () => {
 })
 
 describe("auth helpers (#15)", () => {
-  it("withBearer adds Authorization header", async () => {
+  it("bearer adds Authorization header", async () => {
     const driver = mockDriverFactory({ response: jsonResponse({}) })
-    const m = withBearer(createMisina({ driver, retry: 0 }), "abc123")
+    const m = createMisina({ driver, retry: 0, use: [bearer("abc123")] })
 
     await m.get("https://api.test/")
     expect(getMockApi(driver)!.calls[0]!.headers.authorization).toBe("Bearer abc123")
   })
 
-  it("withBearer accepts function source", async () => {
+  it("bearer accepts function source", async () => {
     const driver = mockDriverFactory({ response: jsonResponse({}) })
-    const m = withBearer(createMisina({ driver, retry: 0 }), () => "dynamic")
+    const m = createMisina({ driver, retry: 0, use: [bearer(() => "dynamic")] })
 
     await m.get("https://api.test/")
     expect(getMockApi(driver)!.calls[0]!.headers.authorization).toBe("Bearer dynamic")
   })
 
-  it("withBasic encodes credentials", async () => {
+  it("basic encodes credentials", async () => {
     const driver = mockDriverFactory({ response: jsonResponse({}) })
-    const m = withBasic(createMisina({ driver, retry: 0 }), "user", "pass")
+    const m = createMisina({ driver, retry: 0, use: [basic("user", "pass")] })
 
     await m.get("https://api.test/")
     const auth = getMockApi(driver)!.calls[0]!.headers.authorization
@@ -168,7 +168,7 @@ describe("cache (#14)", () => {
     })
 
     const store = memoryStore()
-    const m = withCache(createMisina({ driver, retry: 0 }), { store, ttl: 5000 })
+    const m = createMisina({ driver, retry: 0, use: [cache({ store, ttl: 5000 })] })
 
     const a = await m.get<{ count: number }>("https://api.test/")
     const b = await m.get<{ count: number }>("https://api.test/")

--- a/test/graphql.test.ts
+++ b/test/graphql.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
-import { GraphqlAggregateError, withGraphql } from "../src/graphql/index.ts"
+import { createGraphqlClient, GraphqlAggregateError } from "../src/graphql/index.ts"
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -8,7 +8,7 @@ function jsonResponse(body: unknown): Response {
   })
 }
 
-describe("withGraphql — basic POST query/mutate", () => {
+describe("createGraphqlClient — basic POST query/mutate", () => {
   it("query() sends the canonical envelope and returns data", async () => {
     let observedBody: string | null = null
     const driver = {
@@ -19,7 +19,7 @@ describe("withGraphql — basic POST query/mutate", () => {
       },
     }
     const m = createMisina({ driver, retry: 0, baseURL: "https://api.test" })
-    const gql = withGraphql(m)
+    const gql = createGraphqlClient(m)
     const data = await gql.query<{ user: { id: string; name: string } }>(
       "query Get($id: ID!){user(id:$id){id name}}",
       { id: "42" },
@@ -42,7 +42,7 @@ describe("withGraphql — basic POST query/mutate", () => {
       },
     }
     const m = createMisina({ driver, retry: 0, baseURL: "https://api.test" })
-    const gql = withGraphql(m, { getFallbackBelow: 99_999 }) // very high
+    const gql = createGraphqlClient(m, { getFallbackBelow: 99_999 }) // very high
     await gql.mutate("mutation Foo{foo}")
     expect(seen).toEqual(["POST"])
   })
@@ -57,7 +57,7 @@ describe("withGraphql — basic POST query/mutate", () => {
         }),
     }
     const m = createMisina({ driver, retry: 0, baseURL: "https://api.test" })
-    const gql = withGraphql(m)
+    const gql = createGraphqlClient(m)
     try {
       await gql.query("{user{id}}")
       expect.fail("should throw")
@@ -69,7 +69,7 @@ describe("withGraphql — basic POST query/mutate", () => {
   })
 })
 
-describe("withGraphql — APQ", () => {
+describe("createGraphqlClient — APQ", () => {
   it("first attempt sends hash only; PersistedQueryNotFound triggers full retry", async () => {
     const calls: Array<{ envelope: { query?: string; extensions?: unknown } }> = []
     let i = 0
@@ -88,7 +88,7 @@ describe("withGraphql — APQ", () => {
       },
     }
     const m = createMisina({ driver, retry: 0, baseURL: "https://api.test" })
-    const gql = withGraphql(m, { persistedQueries: true })
+    const gql = createGraphqlClient(m, { persistedQueries: true })
     const data = await gql.query<{ user: { id: string } }>("{user{id}}")
     expect(data.user.id).toBe("1")
     expect(calls).toHaveLength(2)
@@ -117,14 +117,14 @@ describe("withGraphql — APQ", () => {
       },
     }
     const m = createMisina({ driver, retry: 0, baseURL: "https://api.test" })
-    const gql = withGraphql(m, { persistedQueries: true })
+    const gql = createGraphqlClient(m, { persistedQueries: true })
     const data = await gql.query<{ ok: boolean }>("{ok}")
     expect(data.ok).toBe(true)
     expect(i).toBe(2)
   })
 })
 
-describe("withGraphql — GET fallback", () => {
+describe("createGraphqlClient — GET fallback", () => {
   it("query under threshold goes via GET", async () => {
     const seen: { method: string; url: string }[] = []
     const driver = {
@@ -135,7 +135,7 @@ describe("withGraphql — GET fallback", () => {
       },
     }
     const m = createMisina({ driver, retry: 0, baseURL: "https://api.test" })
-    const gql = withGraphql(m, { getFallbackBelow: 1500 })
+    const gql = createGraphqlClient(m, { getFallbackBelow: 1500 })
     await gql.query("{ok}")
     expect(seen[0]?.method).toBe("GET")
     expect(seen[0]?.url).toContain("query=")
@@ -151,7 +151,7 @@ describe("withGraphql — GET fallback", () => {
       },
     }
     const m = createMisina({ driver, retry: 0, baseURL: "https://api.test" })
-    const gql = withGraphql(m, { getFallbackBelow: 50 })
+    const gql = createGraphqlClient(m, { getFallbackBelow: 50 })
     await gql.query(`query A{${"a".repeat(100)}}`)
     expect(seen).toEqual(["POST"])
   })

--- a/test/otel.test.ts
+++ b/test/otel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
-import { withOtel, type OtelSpan, type OtelTracer } from "../src/otel/index.ts"
+import { otel, type OtelSpan, type OtelTracer } from "../src/otel/index.ts"
 
 interface RecordedSpan {
   name: string
@@ -50,14 +50,14 @@ function fakeTracer(): { tracer: OtelTracer; spans: RecordedSpan[] } {
   return { tracer, spans }
 }
 
-describe("withOtel — span lifecycle", () => {
+describe("otel — span lifecycle", () => {
   it("creates one CLIENT span per request with semconv attributes and ends it on success", async () => {
     const { tracer, spans } = fakeTracer()
     const driver = {
       name: "x",
       request: async () => new Response("{}", { status: 200 }),
     }
-    const m = withOtel(createMisina({ driver, retry: 0 }), { tracer })
+    const m = createMisina({ driver, retry: 0, use: [otel({ tracer })] })
     await m.get("https://api.example.com:8443/users/42")
     expect(spans).toHaveLength(1)
     const s = spans[0]!
@@ -80,7 +80,7 @@ describe("withOtel — span lifecycle", () => {
       name: "x",
       request: async () => new Response("nope", { status: 500 }),
     }
-    const m = withOtel(createMisina({ driver, retry: 0 }), { tracer })
+    const m = createMisina({ driver, retry: 0, use: [otel({ tracer })] })
     await expect(m.get("https://api.example.com/")).rejects.toBeDefined()
     expect(spans).toHaveLength(1)
     const s = spans[0]!
@@ -98,7 +98,7 @@ describe("withOtel — span lifecycle", () => {
         throw new TypeError("fetch failed")
       },
     }
-    const m = withOtel(createMisina({ driver, retry: 0 }), { tracer })
+    const m = createMisina({ driver, retry: 0, use: [otel({ tracer })] })
     await expect(m.get("https://api.example.com/")).rejects.toBeDefined()
     expect(spans[0]?.status?.code).toBe(2)
     expect(spans[0]?.exceptions).toHaveLength(1)
@@ -115,7 +115,7 @@ describe("withOtel — span lifecycle", () => {
         return new Response("ok", { status: 200 })
       },
     }
-    const m = withOtel(createMisina({ driver, retry: 0 }), { tracer })
+    const m = createMisina({ driver, retry: 0, use: [otel({ tracer })] })
     await m.get("https://api.example.com/")
     expect(observedTp).toBe(
       `00-${spans[0]?.spanContext.traceId}-${spans[0]?.spanContext.spanId}-01`,
@@ -132,7 +132,7 @@ describe("withOtel — span lifecycle", () => {
         return new Response("ok", { status: 200 })
       },
     }
-    const m = withOtel(createMisina({ driver, retry: 0 }), { tracer })
+    const m = createMisina({ driver, retry: 0, use: [otel({ tracer })] })
     const tp = "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01"
     await m.get("https://api.example.com/", { headers: { traceparent: tp } })
     expect(observedTp).toBe(tp)
@@ -148,9 +148,10 @@ describe("withOtel — span lifecycle", () => {
         return new Response("ok", { status: 200 })
       },
     }
-    const m = withOtel(createMisina({ driver, retry: 0 }), {
-      tracer,
-      injectTraceparent: false,
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [otel({ tracer, injectTraceparent: false })],
     })
     await m.get("https://api.example.com/")
     expect(observedTp).toBeNull()
@@ -162,10 +163,17 @@ describe("withOtel — span lifecycle", () => {
       name: "x",
       request: async () => new Response("ok", { status: 200 }),
     }
-    const m = withOtel(createMisina({ driver, retry: 0 }), {
-      tracer,
-      spanName: (req) => `http.${req.method.toLowerCase()} ${new URL(req.url).pathname}`,
-      attributes: { "deployment.environment": "test" },
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        otel({
+          tracer,
+          spanName: (req: Request) =>
+            `http.${req.method.toLowerCase()} ${new URL(req.url).pathname}`,
+          attributes: { "deployment.environment": "test" },
+        }),
+      ],
     })
     await m.get("https://api.example.com/users/42")
     expect(spans[0]?.name).toBe("http.get /users/42")
@@ -178,7 +186,7 @@ describe("withOtel — span lifecycle", () => {
       name: "x",
       request: async () => new Response("ok", { status: 200 }),
     }
-    const m = withOtel(createMisina({ driver, retry: 0 }), { tracer })
+    const m = createMisina({ driver, retry: 0, use: [otel({ tracer })] })
     await Promise.all([
       m.get("https://api.example.com/a"),
       m.get("https://api.example.com/b"),

--- a/test/ratelimit-bucket.test.ts
+++ b/test/ratelimit-bucket.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
-import { withRateLimit } from "../src/ratelimit/index.ts"
+import { rateLimit } from "../src/ratelimit/index.ts"
 
 function recordingDriver(responses: Response[]) {
   let i = 0
@@ -18,10 +18,10 @@ function ok(): Response {
   return new Response("{}", { headers: { "content-type": "application/json" } })
 }
 
-describe("withRateLimit — RPM bucket", () => {
+describe("rateLimit — RPM bucket", () => {
   it("infinite default lets all requests through immediately", async () => {
     const driver = recordingDriver([ok(), ok(), ok()])
-    const m = withRateLimit(createMisina({ driver, retry: 0 }))
+    const m = createMisina({ driver, retry: 0, use: [rateLimit()] })
     await Promise.all([
       m.get("https://x.test/"),
       m.get("https://x.test/"),
@@ -32,7 +32,7 @@ describe("withRateLimit — RPM bucket", () => {
 
   it("starts full — first N requests up to capacity dispatch immediately", async () => {
     const driver = recordingDriver([ok(), ok(), ok(), ok(), ok()])
-    const m = withRateLimit(createMisina({ driver, retry: 0 }), { rpm: 600 })
+    const m = createMisina({ driver, retry: 0, use: [rateLimit({ rpm: 600 })] })
     const start = Date.now()
     await Promise.all([
       m.get("https://x.test/"),
@@ -59,7 +59,7 @@ describe("withRateLimit — RPM bucket", () => {
         return ok()
       },
     }
-    const m = withRateLimit(createMisina({ driver, retry: 0 }), { rpm: 600 }) // 10/sec
+    const m = createMisina({ driver, retry: 0, use: [rateLimit({ rpm: 600 })] }) // 10/sec
     await m.get("https://x.test/") // remaining=0 set
     // Linear refill at 10/sec → ~100ms wait for the next acquire.
     const start = Date.now()
@@ -79,8 +79,11 @@ describe("withRateLimit — RPM bucket", () => {
         return ok()
       },
     }
-    const m = withRateLimit(createMisina({ driver, retry: 0, throwHttpErrors: false }), {
-      rpm: 6000,
+    const m = createMisina({
+      driver,
+      retry: 0,
+      throwHttpErrors: false,
+      use: [rateLimit({ rpm: 6000 })],
     })
     await m.get("https://x.test/") // 429 → drains
     const start = Date.now()
@@ -109,7 +112,7 @@ describe("withRateLimit — RPM bucket", () => {
         return ok()
       },
     }
-    const m = withRateLimit(createMisina({ driver, retry: 0 }), { rpm: 60 })
+    const m = createMisina({ driver, retry: 0, use: [rateLimit({ rpm: 60 })] })
     await m.get("https://x.test/")
     // Now the bucket is bypassed until ~60s from now. Second request should
     // queue; abort should reject it quickly.
@@ -120,19 +123,25 @@ describe("withRateLimit — RPM bucket", () => {
   })
 })
 
-describe("withRateLimit — TPM bucket", () => {
+describe("rateLimit — TPM bucket", () => {
   it("estimateTokens gates the second request when TPM is exhausted", async () => {
     // Simpler check: verify the limiter doesn't crash + estimateTokens
     // is called on the request. Full timing verified in the 429 test.
     let estimateCalls = 0
     const driver = recordingDriver([ok(), ok()])
-    const m = withRateLimit(createMisina({ driver, retry: 0 }), {
-      tpm: 10_000,
-      estimateTokens: (req) => {
-        estimateCalls++
-        void req
-        return 100
-      },
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        rateLimit({
+          tpm: 10_000,
+          estimateTokens: (req: Request) => {
+            estimateCalls++
+            void req
+            return 100
+          },
+        }),
+      ],
     })
     await m.get("https://x.test/")
     await m.get("https://x.test/")

--- a/test/sentry.test.ts
+++ b/test/sentry.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
 import type { SentryHub } from "../src/sentry/index.ts"
-import { withSentry } from "../src/sentry/index.ts"
+import { sentry } from "../src/sentry/index.ts"
 
 type CaptureRecord = { error: unknown; context: Record<string, unknown> | undefined }
 type BreadcrumbRecord = { category?: string; message?: string; data?: Record<string, unknown> }
@@ -25,7 +25,7 @@ function fakeSentry(): SentryHub & {
   }
 }
 
-describe("withSentry — captureException", () => {
+describe("sentry — captureException", () => {
   it("captures HTTPError with request context + status", async () => {
     const Sentry = fakeSentry()
     const driver = {
@@ -36,7 +36,7 @@ describe("withSentry — captureException", () => {
           headers: { "x-request-id": "req_1" },
         }),
     }
-    const m = withSentry(createMisina({ driver, retry: 0 }), { Sentry })
+    const m = createMisina({ driver, retry: 0, use: [sentry({ Sentry })] })
     await expect(m.get("https://x.test/users/42")).rejects.toBeDefined()
     expect(Sentry.exceptions).toHaveLength(1)
     const ctx = Sentry.exceptions[0]?.context as {
@@ -55,18 +55,16 @@ describe("withSentry — captureException", () => {
       name: "x",
       request: async () => new Response("err", { status: 500 }),
     }
-    const m = withSentry(
-      createMisina({
-        driver,
-        retry: 0,
-        headers: {
-          authorization: "Bearer secret",
-          cookie: "session=secret",
-          "x-public": "ok",
-        },
-      }),
-      { Sentry },
-    )
+    const m = createMisina({
+      driver,
+      retry: 0,
+      headers: {
+        authorization: "Bearer secret",
+        cookie: "session=secret",
+        "x-public": "ok",
+      },
+      use: [sentry({ Sentry })],
+    })
     await expect(m.get("https://x.test/")).rejects.toBeDefined()
     const headers = (
       Sentry.exceptions[0]?.context as {
@@ -84,7 +82,7 @@ describe("withSentry — captureException", () => {
       name: "x",
       request: async () => new Response("not found", { status: 404 }),
     }
-    const m = withSentry(createMisina({ driver, retry: 0 }), { Sentry })
+    const m = createMisina({ driver, retry: 0, use: [sentry({ Sentry })] })
     await expect(m.get("https://x.test/")).rejects.toBeDefined()
     expect(Sentry.exceptions).toHaveLength(0)
   })
@@ -95,9 +93,10 @@ describe("withSentry — captureException", () => {
       name: "x",
       request: async () => new Response("not found", { status: 404 }),
     }
-    const m = withSentry(createMisina({ driver, retry: 0 }), {
-      Sentry,
-      captureLevel: "all",
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [sentry({ Sentry, captureLevel: "all" })],
     })
     await expect(m.get("https://x.test/")).rejects.toBeDefined()
     expect(Sentry.exceptions).toHaveLength(1)
@@ -111,9 +110,10 @@ describe("withSentry — captureException", () => {
         throw new TypeError("fetch failed")
       },
     }
-    const m = withSentry(createMisina({ driver, retry: 0 }), {
-      Sentry,
-      captureLevel: "5xx",
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [sentry({ Sentry, captureLevel: "5xx" })],
     })
     await expect(m.get("https://x.test/")).rejects.toBeDefined()
     expect(Sentry.exceptions).toHaveLength(0)
@@ -125,9 +125,11 @@ describe("withSentry — captureException", () => {
       name: "x",
       request: async () => new Response("err", { status: 500 }),
     }
-    const m = withSentry(createMisina({ driver, retry: 0, headers: { "x-api-key": "secret" } }), {
-      Sentry,
-      redactHeaders: ["x-api-key"],
+    const m = createMisina({
+      driver,
+      retry: 0,
+      headers: { "x-api-key": "secret" },
+      use: [sentry({ Sentry, redactHeaders: ["x-api-key"] })],
     })
     await expect(m.get("https://x.test/")).rejects.toBeDefined()
     const headers = (
@@ -139,16 +141,17 @@ describe("withSentry — captureException", () => {
   })
 })
 
-describe("withSentry — successBreadcrumb", () => {
+describe("sentry — successBreadcrumb", () => {
   it("adds a breadcrumb on successful request when enabled", async () => {
     const Sentry = fakeSentry()
     const driver = {
       name: "x",
       request: async () => new Response("{}", { headers: { "content-type": "application/json" } }),
     }
-    const m = withSentry(createMisina({ driver, retry: 0 }), {
-      Sentry,
-      successBreadcrumb: true,
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [sentry({ Sentry, successBreadcrumb: true })],
     })
     await m.get("https://x.test/")
     expect(Sentry.breadcrumbs).toHaveLength(1)
@@ -162,7 +165,7 @@ describe("withSentry — successBreadcrumb", () => {
       name: "x",
       request: async () => new Response("{}", { headers: { "content-type": "application/json" } }),
     }
-    const m = withSentry(createMisina({ driver, retry: 0 }), { Sentry })
+    const m = createMisina({ driver, retry: 0, use: [sentry({ Sentry })] })
     await m.get("https://x.test/")
     expect(Sentry.breadcrumbs).toHaveLength(0)
   })

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { createMisina } from "../src/index.ts"
-import { withTracing } from "../src/tracing/index.ts"
+import { tracing } from "../src/tracing/index.ts"
 
 function recordingDriver(): {
   name: string
@@ -26,10 +26,10 @@ function recordingDriver(): {
   }
 }
 
-describe("withTracing — traceparent generation", () => {
+describe("tracing — traceparent generation", () => {
   it("auto-injects a fresh traceparent in W3C format", async () => {
     const driver = recordingDriver()
-    const m = withTracing(createMisina({ driver, retry: 0 }))
+    const m = createMisina({ driver, retry: 0, use: [tracing()] })
     await m.get("https://x.test/")
     const tp = driver.seen[0]?.traceparent
     expect(tp).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/)
@@ -37,21 +37,21 @@ describe("withTracing — traceparent generation", () => {
 
   it("default flags is 01 (sampled)", async () => {
     const driver = recordingDriver()
-    const m = withTracing(createMisina({ driver, retry: 0 }))
+    const m = createMisina({ driver, retry: 0, use: [tracing()] })
     await m.get("https://x.test/")
     expect(driver.seen[0]?.traceparent?.endsWith("-01")).toBe(true)
   })
 
   it("custom flags are honored", async () => {
     const driver = recordingDriver()
-    const m = withTracing(createMisina({ driver, retry: 0 }), { flags: 0 })
+    const m = createMisina({ driver, retry: 0, use: [tracing({ flags: 0 })] })
     await m.get("https://x.test/")
     expect(driver.seen[0]?.traceparent?.endsWith("-00")).toBe(true)
   })
 
   it("preserves caller-supplied traceparent (does not overwrite)", async () => {
     const driver = recordingDriver()
-    const m = withTracing(createMisina({ driver, retry: 0 }))
+    const m = createMisina({ driver, retry: 0, use: [tracing()] })
     await m.get("https://x.test/", {
       headers: { traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01" },
     })
@@ -62,23 +62,29 @@ describe("withTracing — traceparent generation", () => {
 
   it("each request gets a different traceparent", async () => {
     const driver = recordingDriver()
-    const m = withTracing(createMisina({ driver, retry: 0 }))
+    const m = createMisina({ driver, retry: 0, use: [tracing()] })
     await m.get("https://x.test/")
     await m.get("https://x.test/")
     expect(driver.seen[0]?.traceparent).not.toBe(driver.seen[1]?.traceparent)
   })
 })
 
-describe("withTracing — getCurrentSpan integration", () => {
+describe("tracing — getCurrentSpan integration", () => {
   it("uses provided span context when getCurrentSpan returns one", async () => {
     const driver = recordingDriver()
-    const m = withTracing(createMisina({ driver, retry: 0 }), {
-      getCurrentSpan: () => ({
-        traceId: "0123456789abcdef0123456789abcdef",
-        parentId: "fedcba9876543210",
-        flags: 0x01,
-        state: "vendor=value",
-      }),
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [
+        tracing({
+          getCurrentSpan: () => ({
+            traceId: "0123456789abcdef0123456789abcdef",
+            parentId: "fedcba9876543210",
+            flags: 0x01,
+            state: "vendor=value",
+          }),
+        }),
+      ],
     })
     await m.get("https://x.test/")
     expect(driver.seen[0]?.traceparent).toBe(
@@ -89,19 +95,19 @@ describe("withTracing — getCurrentSpan integration", () => {
 
   it("falls back to fresh traceparent when getCurrentSpan returns null", async () => {
     const driver = recordingDriver()
-    const m = withTracing(createMisina({ driver, retry: 0 }), {
-      getCurrentSpan: () => null,
-    })
+    const m = createMisina({ driver, retry: 0, use: [tracing({ getCurrentSpan: () => null })] })
     await m.get("https://x.test/")
     expect(driver.seen[0]?.traceparent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/)
   })
 })
 
-describe("withTracing — baggage", () => {
+describe("tracing — baggage", () => {
   it("adds Baggage header from static record", async () => {
     const driver = recordingDriver()
-    const m = withTracing(createMisina({ driver, retry: 0 }), {
-      baggage: { tenant: "acme", env: "prod" },
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [tracing({ baggage: { tenant: "acme", env: "prod" } })],
     })
     await m.get("https://x.test/")
     expect(driver.seen[0]?.baggage).toContain("tenant=acme")
@@ -111,8 +117,10 @@ describe("withTracing — baggage", () => {
   it("baggage from function is evaluated per request", async () => {
     const driver = recordingDriver()
     let n = 0
-    const m = withTracing(createMisina({ driver, retry: 0 }), {
-      baggage: () => ({ seq: String(++n) }),
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [tracing({ baggage: () => ({ seq: String(++n) }) })],
     })
     await m.get("https://x.test/")
     await m.get("https://x.test/")
@@ -122,8 +130,10 @@ describe("withTracing — baggage", () => {
 
   it("URL-encodes baggage keys/values", async () => {
     const driver = recordingDriver()
-    const m = withTracing(createMisina({ driver, retry: 0 }), {
-      baggage: { "user id": "alice & bob" },
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [tracing({ baggage: { "user id": "alice & bob" } })],
     })
     await m.get("https://x.test/")
     expect(driver.seen[0]?.baggage).toBe("user%20id=alice%20%26%20bob")
@@ -131,8 +141,10 @@ describe("withTracing — baggage", () => {
 
   it("preserves caller-supplied Baggage header", async () => {
     const driver = recordingDriver()
-    const m = withTracing(createMisina({ driver, retry: 0 }), {
-      baggage: { tenant: "acme" },
+    const m = createMisina({
+      driver,
+      retry: 0,
+      use: [tracing({ baggage: { tenant: "acme" } })],
     })
     await m.get("https://x.test/", { headers: { baggage: "foo=bar" } })
     expect(driver.seen[0]?.baggage).toBe("foo=bar")
@@ -140,7 +152,7 @@ describe("withTracing — baggage", () => {
 
   it("no baggage → no header", async () => {
     const driver = recordingDriver()
-    const m = withTracing(createMisina({ driver, retry: 0 }))
+    const m = createMisina({ driver, retry: 0, use: [tracing()] })
     await m.get("https://x.test/")
     expect(driver.seen[0]?.baggage).toBeNull()
   })


### PR DESCRIPTION
## Summary

- Drops every `withX(misina, opts)` helper in favor of factory-returned `MisinaPlugin`s composed via `createMisina({ use: [...] })`. Hook-only plugins (auth, cache, tracing, …) and wrapping plugins (`dedupe`, `breaker`) share a single shape.
- `createMisina` becomes `<const TPlugins>` generic; a tail-recursive `ApplyPlugins<TPlugins>` accumulator intersects each plugin's `TExt` onto the returned client, so `breaker()` keeps its `.breaker` handle typed without manual annotation.
- `withGraphql` is the only carve-out (returns a `GraphqlClient`, not a `Misina`) — renamed to `createGraphqlClient(misina, opts)` and documented as a sibling helper, not a plugin.

Idea credit goes to [@aleclarson](https://github.com/aleclarson) — thanks for the nudge that the `with*` wrapping was hostile DX.

## Migration

```diff
- import { withBearer, withCache, withCircuitBreaker } from "misina/..."
- const api = withCircuitBreaker(withCache(withBearer(createMisina({ baseURL }), token), opts), { failureThreshold: 5 })
+ import { bearer } from "misina/auth"
+ import { cache } from "misina/cache"
+ import { breaker } from "misina/breaker"
+ const api = createMisina({
+   baseURL,
+   use: [bearer(token), cache(opts), breaker({ failureThreshold: 5 })],
+ })
```

Full mapping in the commit body. `withGraphql` → `createGraphqlClient(misina, opts)`.

## TS-go bookkeeping (vs. baseline)

| | before | after |
|---|---|---|
| Types | 49,226 | 50,829 (+3.3%) |
| Instantiations | 52,892 | 53,520 (+1.2%) |
| `tsgo --noEmit` total | 0.095s | 0.108s |

Accumulator is tail-recursive (TS-go fast path, depth limit 1000), `TExt extends object` blocks the intersection × union cross-product trap.

## Bundle budget

- `misina.mjs`: 23 KB → 24 KB (plugin loop + duplicate-name guard, ~+720 B)
- `digest/index.mjs`: 3000 B → 3100 B (plugin object literal overhead, +23 B)
- All other subpaths unchanged or smaller.

## Test plan

- [x] `pnpm test` (820/820 passing — lint + tsgo + vitest)
- [x] `pnpm bundle-budget` (all subpaths within budget)
- [x] Verified no `with*` references remain in `src/`, `test/`, or `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)