### PR TITLE
feat(typed)(#111): per-status-code responses + safe mode on TypedMisina

### DIFF
--- a/README.md
+++ b/README.md
@@ -1851,6 +1851,41 @@ const list = await api.get("/users", { query: { page: 2 } })
 
 Path params are substituted at runtime: `/users/:id` → `/users/42` (also `{id}` syntax).
 
+### Per-status-code `responses` map
+
+Beyond the `response: T` shorthand, each endpoint can declare a full
+per-status-code map. Throwing methods still resolve to the union of 2xx
+bodies; `.safe.*` methods discriminate every documented status:
+
+```ts
+type Api = {
+  "GET /users/:id": {
+    params: { id: string }
+    responses: {
+      200: User
+      404: { message: string }
+      429: { retryAfter: number }
+    }
+  }
+}
+
+const api = createMisinaTyped<Api>({ baseURL: "https://api.example.com" })
+
+const result = await api.safe.get("/users/:id", { params: { id: "42" } })
+
+if (result.ok) {
+  result.data // User
+  result.status // 200
+} else {
+  if (result.error.status === 404) result.error.data.message // string
+  if (result.error.status === 429) result.error.data.retryAfter // number
+}
+```
+
+The throwing surface (`api.get(...)`) is unchanged: it returns the
+2xx body as before. `response: T` remains valid as shorthand for
+`responses: { 200: T }`.
+
 For one-off URL building outside the typed client, use `path()`:
 
 ```ts

--- a/examples/07-typed.ts
+++ b/examples/07-typed.ts
@@ -22,7 +22,11 @@ type GitHubApi = {
   "GET /users/:login": { params: { login: string }; response: User }
   "GET /repos/:owner/:repo": {
     params: { owner: string; repo: string }
-    response: Repo
+    responses: {
+      200: Repo
+      404: { message: string; documentation_url?: string }
+      403: { message: string }
+    }
   }
 }
 
@@ -46,3 +50,14 @@ const { data: repo } = await gh.get("/repos/:owner/:repo", {
 
 console.log(`${repo.full_name} — ★ ${repo.stargazers_count} — ${repo.language ?? "no language"}`)
 console.log(repo.description ?? "(no description)")
+
+const result = await gh.safe.get("/repos/:owner/:repo", {
+  params: { owner: "octocat", repo: "definitely-not-a-real-repo" },
+})
+
+if (result.ok) {
+  console.log(`fetched ${result.data.full_name}`)
+} else {
+  if (result.error.status === 404) console.log(`not found: ${result.error.data.message}`)
+  if (result.error.status === 403) console.log(`forbidden: ${result.error.data.message}`)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,8 +84,16 @@ export type {
 export type {
   EndpointDef,
   EndpointsMap,
+  ErrorCodes,
+  ResponsesOf,
   StandardIssue,
   StandardPathItem,
   StandardSchemaV1,
+  SuccessBodyOf,
+  SuccessCodes,
   TypedMisina,
+  TypedSafeErr,
+  TypedSafeMisina,
+  TypedSafeOk,
+  TypedSafeResult,
 } from "./typed.ts"

--- a/src/typed.ts
+++ b/src/typed.ts
@@ -17,16 +17,63 @@
  */
 
 import { createMisina } from "./misina.ts"
-import type { Misina, MisinaOptions, MisinaResponse, MisinaResponsePromise } from "./types.ts"
+import { HTTPError } from "./errors/http.ts"
+import type {
+  Misina,
+  MisinaOptions,
+  MisinaRequestInit,
+  MisinaResponse,
+  MisinaResponsePromise,
+} from "./types.ts"
 
 export interface EndpointDef {
   params?: Record<string, string | number>
   query?: Record<string, unknown>
   body?: unknown
   response?: unknown
+  responses?: Record<number, unknown>
 }
 
 export type EndpointsMap = Record<string, EndpointDef>
+
+/** 2xx codes recognized as success branches by `.safe.*` typed results. */
+export type SuccessCodes = 200 | 201 | 202 | 204
+/** 4xx/5xx codes recognized as error branches by `.safe.*` typed results. */
+export type ErrorCodes = 400 | 401 | 403 | 404 | 409 | 410 | 422 | 429 | 500 | 502 | 503
+
+/**
+ * Normalize an `EndpointDef`'s response declaration into a `Record<number, _>`
+ * map. `responses` wins; otherwise `response: T` becomes `{ 200: T }`; an
+ * endpoint with neither falls back to `Record<number, unknown>`.
+ */
+export type ResponsesOf<D> = D extends { responses: infer R }
+  ? R
+  : D extends { response: infer T }
+    ? { 200: T }
+    : Record<number, unknown>
+
+export type SuccessBodyOf<R> = [keyof R & SuccessCodes] extends [never]
+  ? unknown
+  : { [K in keyof R & SuccessCodes]: R[K] }[keyof R & SuccessCodes]
+
+export type TypedSafeOk<R> = {
+  ok: true
+  data: SuccessBodyOf<R>
+  status: keyof R & SuccessCodes
+  response: Response
+  error?: undefined
+}
+
+export type TypedSafeErr<R> = {
+  ok: false
+  data?: undefined
+  error: [keyof R & ErrorCodes] extends [never]
+    ? { status: number; data: unknown }
+    : { [K in keyof R & ErrorCodes]: { status: K; data: R[K] } }[keyof R & ErrorCodes]
+  response: Response | undefined
+}
+
+export type TypedSafeResult<R> = TypedSafeOk<R> | TypedSafeErr<R>
 
 type Method<S extends string> = S extends `${infer M} ${string}` ? M : never
 type Path<S extends string> = S extends `${string} ${infer P}` ? P : never
@@ -41,7 +88,7 @@ type CallInit<E> = Omit<MisinaOptions, "headers"> & {
   (E extends { query: infer Q } ? { query: Q } : { query?: Record<string, unknown> }) &
   (E extends { body: infer B } ? { body: B } : {})
 
-type Response<E> = MisinaResponsePromise<E extends { response: infer R } ? R : unknown>
+type ResponsePromise<E> = MisinaResponsePromise<SuccessBodyOf<ResponsesOf<E>>>
 
 // True when the endpoint has no required `params`, `query`, or `body`. In
 // that case the call's `init` argument should be optional so users can write
@@ -56,28 +103,52 @@ type HasRequiredFields<E> = E extends { params: unknown }
 
 type CallArgs<E> = HasRequiredFields<E> extends true ? [init: CallInit<E>] : [init?: CallInit<E>]
 
-export interface TypedMisina<E extends EndpointsMap> {
-  raw: Misina
+export interface TypedSafeMisina<E extends EndpointsMap> {
   get: <P extends keyof EndpointsOfMethod<E, "GET"> & string>(
     path: P,
     ...args: CallArgs<EndpointsOfMethod<E, "GET">[P]>
-  ) => Response<EndpointsOfMethod<E, "GET">[P]>
+  ) => Promise<TypedSafeResult<ResponsesOf<EndpointsOfMethod<E, "GET">[P]>>>
   post: <P extends keyof EndpointsOfMethod<E, "POST"> & string>(
     path: P,
     ...args: CallArgs<EndpointsOfMethod<E, "POST">[P]>
-  ) => Response<EndpointsOfMethod<E, "POST">[P]>
+  ) => Promise<TypedSafeResult<ResponsesOf<EndpointsOfMethod<E, "POST">[P]>>>
   put: <P extends keyof EndpointsOfMethod<E, "PUT"> & string>(
     path: P,
     ...args: CallArgs<EndpointsOfMethod<E, "PUT">[P]>
-  ) => Response<EndpointsOfMethod<E, "PUT">[P]>
+  ) => Promise<TypedSafeResult<ResponsesOf<EndpointsOfMethod<E, "PUT">[P]>>>
   patch: <P extends keyof EndpointsOfMethod<E, "PATCH"> & string>(
     path: P,
     ...args: CallArgs<EndpointsOfMethod<E, "PATCH">[P]>
-  ) => Response<EndpointsOfMethod<E, "PATCH">[P]>
+  ) => Promise<TypedSafeResult<ResponsesOf<EndpointsOfMethod<E, "PATCH">[P]>>>
   delete: <P extends keyof EndpointsOfMethod<E, "DELETE"> & string>(
     path: P,
     ...args: CallArgs<EndpointsOfMethod<E, "DELETE">[P]>
-  ) => Response<EndpointsOfMethod<E, "DELETE">[P]>
+  ) => Promise<TypedSafeResult<ResponsesOf<EndpointsOfMethod<E, "DELETE">[P]>>>
+}
+
+export interface TypedMisina<E extends EndpointsMap> {
+  raw: Misina
+  safe: TypedSafeMisina<E>
+  get: <P extends keyof EndpointsOfMethod<E, "GET"> & string>(
+    path: P,
+    ...args: CallArgs<EndpointsOfMethod<E, "GET">[P]>
+  ) => ResponsePromise<EndpointsOfMethod<E, "GET">[P]>
+  post: <P extends keyof EndpointsOfMethod<E, "POST"> & string>(
+    path: P,
+    ...args: CallArgs<EndpointsOfMethod<E, "POST">[P]>
+  ) => ResponsePromise<EndpointsOfMethod<E, "POST">[P]>
+  put: <P extends keyof EndpointsOfMethod<E, "PUT"> & string>(
+    path: P,
+    ...args: CallArgs<EndpointsOfMethod<E, "PUT">[P]>
+  ) => ResponsePromise<EndpointsOfMethod<E, "PUT">[P]>
+  patch: <P extends keyof EndpointsOfMethod<E, "PATCH"> & string>(
+    path: P,
+    ...args: CallArgs<EndpointsOfMethod<E, "PATCH">[P]>
+  ) => ResponsePromise<EndpointsOfMethod<E, "PATCH">[P]>
+  delete: <P extends keyof EndpointsOfMethod<E, "DELETE"> & string>(
+    path: P,
+    ...args: CallArgs<EndpointsOfMethod<E, "DELETE">[P]>
+  ) => ResponsePromise<EndpointsOfMethod<E, "DELETE">[P]>
 }
 
 export function createMisinaTyped<E extends EndpointsMap>(
@@ -85,23 +156,63 @@ export function createMisinaTyped<E extends EndpointsMap>(
 ): TypedMisina<E> {
   const raw = createMisina(defaults)
 
+  function resolveUrl(path: string, init: Record<string, unknown>): string {
+    const params = init.params as Record<string, string | number> | undefined
+    return params ? substitutePathParams(path, params) : path
+  }
+
+  function buildOptions(method: string, init: Record<string, unknown>): MisinaRequestInit {
+    const { params: _omit, body, ...rest } = init
+    void _omit
+    if (method === "GET" || method === "DELETE" || method === "HEAD" || method === "OPTIONS") {
+      return { ...(rest as MisinaRequestInit), method: method as "GET" }
+    }
+    return { ...(rest as MisinaRequestInit), method: method as "POST", body }
+  }
+
   function call<R>(
     method: string,
     path: string,
     init: Record<string, unknown> = {},
   ): MisinaResponsePromise<R> {
-    const params = init.params as Record<string, string | number> | undefined
-    const url = params ? substitutePathParams(path, params) : path
-    const { params: _omit, body, ...rest } = init
-    void _omit
-    if (method === "GET" || method === "DELETE" || method === "HEAD" || method === "OPTIONS") {
-      return raw.request<R>(url, { ...(rest as MisinaOptions), method: method as "GET" })
+    return raw.request<R>(resolveUrl(path, init), buildOptions(method, init))
+  }
+
+  type LooseSafeResult =
+    | { ok: true; data: unknown; status: number; response: Response; error?: undefined }
+    | {
+        ok: false
+        data?: undefined
+        error: { status: number; data: unknown }
+        response: Response | undefined
+      }
+
+  async function safeCall(
+    method: string,
+    path: string,
+    init: Record<string, unknown> = {},
+  ): Promise<LooseSafeResult> {
+    try {
+      const res = await raw.request<unknown>(resolveUrl(path, init), buildOptions(method, init))
+      return { ok: true, data: res.data, status: res.status, response: res.raw }
+    } catch (e) {
+      if (e instanceof HTTPError) {
+        return {
+          ok: false,
+          error: { status: e.status, data: e.data },
+          response: e.response,
+        }
+      }
+      // Network / timeout / other non-HTTP errors don't fit the per-status
+      // shape — surface a synthetic error envelope so callers can still
+      // discriminate on `ok`. Rethrowing would defeat .safe's purpose.
+      const err = e as Error & { status?: number; data?: unknown }
+      return {
+        ok: false,
+        error: { status: err.status ?? 0, data: err.data ?? err.message },
+        response: undefined,
+      }
     }
-    return raw.request<R>(url, {
-      ...(rest as MisinaOptions),
-      method: method as "POST",
-      body,
-    })
   }
 
   const make =
@@ -109,8 +220,22 @@ export function createMisinaTyped<E extends EndpointsMap>(
     (path: string, init?: Record<string, unknown>): MisinaResponsePromise<unknown> =>
       call(method, path, init)
 
+  const makeSafe =
+    (method: string) =>
+    (path: string, init?: Record<string, unknown>): Promise<LooseSafeResult> =>
+      safeCall(method, path, init)
+
+  const safe = {
+    get: makeSafe("GET"),
+    post: makeSafe("POST"),
+    put: makeSafe("PUT"),
+    patch: makeSafe("PATCH"),
+    delete: makeSafe("DELETE"),
+  } as unknown as TypedSafeMisina<E>
+
   return {
     raw,
+    safe,
     get: make("GET") as TypedMisina<E>["get"],
     post: make("POST") as TypedMisina<E>["post"],
     put: make("PUT") as TypedMisina<E>["put"],

--- a/test/typed-safe.test.ts
+++ b/test/typed-safe.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, expectTypeOf, it } from "vitest"
+import { createMisinaTyped } from "../src/index.ts"
+import type { ResponsesOf, SuccessBodyOf, TypedSafeResult } from "../src/typed.ts"
+import mockDriverFactory from "../src/driver/mock.ts"
+
+interface User {
+  id: string
+  name: string
+}
+interface NotFound {
+  message: string
+}
+interface RateLimited {
+  retryAfter: number
+}
+
+type Api = {
+  "GET /users/:id": {
+    params: { id: string }
+    responses: {
+      200: User
+      404: NotFound
+      429: RateLimited
+    }
+  }
+  "GET /health": { response: { ok: boolean } }
+  "POST /users": {
+    body: { name: string }
+    responses: { 201: User; 422: { issues: string[] } }
+  }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+describe("createMisinaTyped — responses map", () => {
+  it("response: T shorthand still resolves to 200 body for throwing methods", async () => {
+    const driver = mockDriverFactory({ response: jsonResponse({ ok: true }) })
+    const api = createMisinaTyped<Api>({ driver, retry: 0, baseURL: "https://api.test" })
+    const res = await api.get("/health")
+    expect(res.data).toEqual({ ok: true })
+    expectTypeOf(res.data).toEqualTypeOf<{ ok: boolean }>()
+  })
+
+  it("responses: { 200, 404, 429 } resolves throwing get to the 2xx body", async () => {
+    const driver = mockDriverFactory({ response: jsonResponse({ id: "42", name: "Ada" }) })
+    const api = createMisinaTyped<Api>({ driver, retry: 0, baseURL: "https://api.test" })
+    const res = await api.get("/users/:id", { params: { id: "42" } })
+    expectTypeOf(res.data).toEqualTypeOf<User>()
+    expect(res.data).toEqual({ id: "42", name: "Ada" })
+  })
+})
+
+describe("createMisinaTyped — .safe namespace", () => {
+  it("safe.get returns ok=true with success body on 200", async () => {
+    const driver = mockDriverFactory({ response: jsonResponse({ id: "42", name: "Ada" }) })
+    const api = createMisinaTyped<Api>({ driver, retry: 0, baseURL: "https://api.test" })
+
+    const result = await api.safe.get("/users/:id", { params: { id: "42" } })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expectTypeOf(result.data).toEqualTypeOf<User>()
+      expect(result.data).toEqual({ id: "42", name: "Ada" })
+      expect(result.status).toBe(200)
+      expect(result.response).toBeInstanceOf(Response)
+    }
+  })
+
+  it("safe.get returns ok=false with error.status === 404 and typed data", async () => {
+    const driver = mockDriverFactory({
+      response: jsonResponse({ message: "not found" }, 404),
+    })
+    const api = createMisinaTyped<Api>({ driver, retry: 0, baseURL: "https://api.test" })
+
+    const result = await api.safe.get("/users/:id", { params: { id: "x" } })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect([404, 429]).toContain(result.error.status)
+      // Discriminated narrowing on status:
+      if (result.error.status === 404) {
+        expectTypeOf(result.error.data).toEqualTypeOf<NotFound>()
+        expect(result.error.data.message).toBe("not found")
+      }
+    }
+  })
+
+  it("safe.get carries 429 body shape on rate-limit", async () => {
+    const driver = mockDriverFactory({
+      response: jsonResponse({ retryAfter: 30 }, 429),
+    })
+    const api = createMisinaTyped<Api>({ driver, retry: 0, baseURL: "https://api.test" })
+
+    const result = await api.safe.get("/users/:id", { params: { id: "x" } })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok && result.error.status === 429) {
+      expectTypeOf(result.error.data).toEqualTypeOf<RateLimited>()
+      expect(result.error.data.retryAfter).toBe(30)
+    }
+  })
+
+  it("safe.post returns ok=true with 201 body", async () => {
+    const driver = mockDriverFactory({
+      response: jsonResponse({ id: "7", name: "Lin" }, 201),
+    })
+    const api = createMisinaTyped<Api>({ driver, retry: 0, baseURL: "https://api.test" })
+
+    const result = await api.safe.post("/users", { body: { name: "Lin" } })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expectTypeOf(result.data).toEqualTypeOf<User>()
+      expect(result.status).toBe(201)
+    }
+  })
+
+  it("safe.post returns ok=false with 422 validation error", async () => {
+    const driver = mockDriverFactory({
+      response: jsonResponse({ issues: ["name too short"] }, 422),
+    })
+    const api = createMisinaTyped<Api>({ driver, retry: 0, baseURL: "https://api.test" })
+
+    const result = await api.safe.post("/users", { body: { name: "" } })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok && result.error.status === 422) {
+      expectTypeOf(result.error.data).toEqualTypeOf<{ issues: string[] }>()
+      expect(result.error.data.issues).toEqual(["name too short"])
+    }
+  })
+
+  it("safe.get for response-shorthand endpoint still works", async () => {
+    const driver = mockDriverFactory({ response: jsonResponse({ ok: true }) })
+    const api = createMisinaTyped<Api>({ driver, retry: 0, baseURL: "https://api.test" })
+
+    const result = await api.safe.get("/health")
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expectTypeOf(result.data).toEqualTypeOf<{ ok: boolean }>()
+    }
+  })
+})
+
+describe("ResponsesOf / SuccessBodyOf — type-only narrowing", () => {
+  it("ResponsesOf prefers explicit responses over response shorthand", () => {
+    type R1 = ResponsesOf<{ responses: { 200: User; 404: NotFound } }>
+    expectTypeOf<R1>().toEqualTypeOf<{ 200: User; 404: NotFound }>()
+  })
+
+  it("ResponsesOf normalizes response: T to { 200: T }", () => {
+    type R2 = ResponsesOf<{ response: User }>
+    expectTypeOf<R2>().toEqualTypeOf<{ 200: User }>()
+  })
+
+  it("SuccessBodyOf unions every 2xx body", () => {
+    type R = { 200: User; 201: { id: string }; 404: NotFound }
+    type S = SuccessBodyOf<R>
+    expectTypeOf<S>().toEqualTypeOf<User | { id: string }>()
+  })
+
+  it("TypedSafeResult is a discriminated union by ok", () => {
+    type R = { 200: User; 404: NotFound }
+    type T = TypedSafeResult<R>
+    type Ok = Extract<T, { ok: true }>
+    type Err = Extract<T, { ok: false }>
+    expectTypeOf<Ok["data"]>().toEqualTypeOf<User>()
+    expectTypeOf<Err["error"]>().toEqualTypeOf<{ status: 404; data: NotFound }>()
+  })
+})

--- a/test/typed-safe.test.ts
+++ b/test/typed-safe.test.ts
@@ -146,6 +146,24 @@ describe("createMisinaTyped — .safe namespace", () => {
       expectTypeOf(result.data).toEqualTypeOf<{ ok: boolean }>()
     }
   })
+
+  it("safe.get surfaces network errors as ok=false with status 0 instead of throwing", async () => {
+    const driver = {
+      name: "boom",
+      request: async (): Promise<Response> => {
+        throw Object.assign(new TypeError("fetch failed"), { name: "TypeError" })
+      },
+    }
+    const api = createMisinaTyped<Api>({ driver, retry: 0, baseURL: "https://api.test" })
+
+    const result = await api.safe.get("/users/:id", { params: { id: "x" } })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.status).toBe(0)
+      expect(result.response).toBeUndefined()
+    }
+  })
 })
 
 describe("ResponsesOf / SuccessBodyOf — type-only narrowing", () => {

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -13,6 +13,7 @@ import { bearer } from "../src/auth/index.ts"
 import { breaker, type BreakerHandle } from "../src/breaker/index.ts"
 import {
   createMisina,
+  createMisinaTyped,
   type HTTPError,
   isHTTPError,
   isMisinaError,
@@ -23,7 +24,9 @@ import {
   type MisinaResponse,
   type MisinaResponsePromise,
   type MisinaResult,
+  type TypedMisina,
 } from "../src/index.ts"
+import type { TypedSafeResult } from "../src/typed.ts"
 import { tracing } from "../src/tracing/index.ts"
 
 describe("createMisina return type", () => {
@@ -141,6 +144,40 @@ describe("error narrowing — type guards", () => {
     if (isMisinaError(err)) {
       expectTypeOf(err.message).toEqualTypeOf<string>()
     }
+  })
+})
+
+describe("TypedMisina.safe — typed per-status-code result", () => {
+  type Api = {
+    "GET /users/:id": {
+      params: { id: string }
+      responses: {
+        200: { id: string; name: string }
+        404: { message: string }
+        429: { retryAfter: number }
+      }
+    }
+  }
+
+  it("TypedMisina<E>['safe']['get'] returns TypedSafeResult of the responses map", () => {
+    const api = createMisinaTyped<Api>()
+    expectTypeOf(api.safe).toBeObject()
+    expectTypeOf(api.safe.get).toBeFunction()
+    type Result = Awaited<ReturnType<typeof api.safe.get<"/users/:id">>>
+    expectTypeOf<Result>().toEqualTypeOf<
+      TypedSafeResult<{
+        200: { id: string; name: string }
+        404: { message: string }
+        429: { retryAfter: number }
+      }>
+    >()
+  })
+
+  it("TypedMisina exposes raw + safe alongside throwing methods", () => {
+    type T = TypedMisina<Api>
+    expectTypeOf<T["raw"]>().toEqualTypeOf<Misina>()
+    expectTypeOf<T["safe"]>().toBeObject()
+    expectTypeOf<T["get"]>().toBeFunction()
   })
 })
 


### PR DESCRIPTION
## Summary

Closes #111. Two additions to `createMisinaTyped`:

1. **`responses` map on `EndpointDef`** — declare a body type per status code:
   ```ts
   "GET /users/:id": {
     params: { id: string }
     responses: { 200: User; 404: { message: string }; 429: { retryAfter: number } }
   }
   ```
   The throwing methods (`api.get`, etc.) now return the union of all declared 2xx bodies (`SuccessBodyOf<R>`), which collapses to `T` when only 200 is declared. The existing `response: T` shorthand is normalized to `responses: { 200: T }` via `ResponsesOf<D>`.

2. **`.safe` namespace on `TypedMisina`** — go-style discriminated result with full per-status narrowing:
   ```ts
   const result = await api.safe.get("/users/:id", { params: { id: "42" } })
   if (result.ok) {
     result.data    // User
     result.status  // 200 | 201 | 202 | 204 (intersected with declared keys)
   } else {
     if (result.error.status === 404) result.error.data.message     // string
     if (result.error.status === 429) result.error.data.retryAfter  // number
   }
   ```
   Underlying call goes through the raw `Misina` request path; HTTPError is unpacked into `{ status, data }`. Network/timeout errors surface with `status: 0` rather than throwing, so the `ok` discriminator is reliable.

## API surface added

Public types re-exported from `misina`: `ResponsesOf`, `SuccessBodyOf`, `SuccessCodes` (`200|201|202|204`), `ErrorCodes` (`400|401|403|404|409|410|422|429|500|502|503`), `TypedSafeOk`, `TypedSafeErr`, `TypedSafeResult`, `TypedSafeMisina`.

## Backward compatibility

- Every existing test in `test/typed-edges.test.ts` and `test/types.test.ts` passes unchanged.
- `response: T` shorthand resolves identically through both throwing and safe surfaces.
- `TypedMisina.raw` remains the escape hatch for full `Misina` features.
- The `misina/openapi` adapter (which emits `response: T` per-operation today) is unaffected.

## Tests added

- `test/typed-safe.test.ts` (new, 11 tests): `responses` map, shorthand fallback, 200/201/404/422/429 narrowing on `safe.get` / `safe.post`, type-only narrowing of `ResponsesOf` / `SuccessBodyOf` / `TypedSafeResult`.
- `test/types.test.ts` (extended): contract pinning for `TypedMisina<E>['safe']['get']`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run test/typed-edges.test.ts test/typed-safe.test.ts test/types.test.ts` — 39 pass
- [x] `pnpm vitest run` — 850/850 pass
- [x] `pnpm lint` — no new warnings/errors from changed files
- [x] `pnpm fmt` applied
- [x] README + `examples/07-typed.ts` demo the new shape