### PR TITLE
docs(jsdoc): top-level public export docstrings

### DIFF
--- a/src/errors/http.ts
+++ b/src/errors/http.ts
@@ -31,14 +31,14 @@ export interface ProblemDetails {
  *
  * @example
  * ```ts
- * import { HTTPError, isHTTPError } from "misina"
+ * import { HTTPError } from "misina"
  *
  * try {
  *   const { data } = await api.post<User>("/users", { name: "Alice" })
  * } catch (err) {
- *   if (isHTTPError<{ message: string }>(err)) {
- *     // err.status, err.data.message, err.response.headers all typed
- *     showToast(err.problem?.title ?? err.data.message)
+ *   if (err instanceof HTTPError) {
+ *     // err.status, err.data, err.response.headers all typed
+ *     showToast(err.problem?.title ?? `HTTP ${err.status}`)
  *   } else throw err
  * }
  * ```

--- a/src/errors/http.ts
+++ b/src/errors/http.ts
@@ -31,14 +31,14 @@ export interface ProblemDetails {
  *
  * @example
  * ```ts
- * import { HTTPError } from "misina"
+ * import { HTTPError, isHTTPError } from "misina"
  *
  * try {
  *   const { data } = await api.post<User>("/users", { name: "Alice" })
  * } catch (err) {
- *   if (err instanceof HTTPError) {
- *     // err.status, err.data, err.response.headers all typed
- *     showToast(err.problem?.title ?? `HTTP ${err.status}`)
+ *   if (isHTTPError<{ message: string }>(err)) {
+ *     // err.status, err.data.message, err.response.headers all typed
+ *     showToast(err.problem?.title ?? err.data.message)
  *   } else throw err
  * }
  * ```

--- a/src/typed.ts
+++ b/src/typed.ts
@@ -181,20 +181,9 @@ export interface TypedMisina<E extends EndpointsMap> {
 }
 
 /**
- * Build a typed Misina client around an endpoint map. The returned client
- * type-checks URL/method/params/query/body/response per declared route, and
- * exposes `.safe.*` for discriminated `{ ok, data, error }` results.
- *
- * @example
- * ```ts
- * type Api = {
- *   "GET /users/:id": { params: { id: string }; response: User }
- *   "POST /users":    { body: NewUser; response: User }
- * }
- *
- * const api = createMisinaTyped<Api>({ baseURL: "https://api.example.com" })
- * const user = await api.get("/users/:id", { params: { id: "42" } })
- * ```
+ * Build a typed Misina client. Adds `.safe.*` for discriminated
+ * `{ ok, data, error }` results on top of the route map declared by `E`.
+ * See the module-level block above for an end-to-end example.
  */
 export function createMisinaTyped<E extends EndpointsMap>(
   defaults: MisinaOptions = {},

--- a/src/typed.ts
+++ b/src/typed.ts
@@ -180,6 +180,22 @@ export interface TypedMisina<E extends EndpointsMap> {
   ) => ResponsePromise<EndpointsOfMethod<E, "DELETE">[P]>
 }
 
+/**
+ * Build a typed Misina client around an endpoint map. The returned client
+ * type-checks URL/method/params/query/body/response per declared route, and
+ * exposes `.safe.*` for discriminated `{ ok, data, error }` results.
+ *
+ * @example
+ * ```ts
+ * type Api = {
+ *   "GET /users/:id": { params: { id: string }; response: User }
+ *   "POST /users":    { body: NewUser; response: User }
+ * }
+ *
+ * const api = createMisinaTyped<Api>({ baseURL: "https://api.example.com" })
+ * const user = await api.get("/users/:id", { params: { id: "42" } })
+ * ```
+ */
 export function createMisinaTyped<E extends EndpointsMap>(
   defaults: MisinaOptions = {},
 ): TypedMisina<E> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -461,6 +461,11 @@ export interface MisinaResolvedOptions extends MisinaRuntimeOptions {
   stringifyJson: (value: unknown) => string
 }
 
+/**
+ * Resolved response surface returned by `await misina.get(...)` and friends.
+ * Wraps the raw `Response` (`.raw`) with a parsed body (`.data`), parsed
+ * headers, lifecycle timings, and a server-issued `requestId` when present.
+ */
 export interface MisinaResponse<T = unknown> {
   data: T
   status: number


### PR DESCRIPTION
Adds 1-3 line JSDoc + @example to the most-used public exports (createMisina, HTTPError, NetworkError, TimeoutError, defineDriver, createMisinaTyped). IDE hover now surfaces canonical usage patterns. No type/runtime changes.