### PR TITLE
test(audit-fixes): de-flake TimeoutError test (closes #120)

### DIFF
--- a/test/audit-fixes.test.ts
+++ b/test/audit-fixes.test.ts
@@ -65,12 +65,16 @@ describe("audit pass 1 — Retry-After parsing (Bug 8)", () => {
 
 describe("audit pass 1 — TimeoutError carries the configured timeout (Bug 18)", () => {
   it("error.timeout reflects the option, not 0", async () => {
+    // The contract under test is the *shape* of the error (carries the
+    // configured `timeout` option, message includes "25ms"), not the wall-clock
+    // behavior of `AbortSignal.timeout`. Driving the rejection synchronously
+    // with a TimeoutError-named DOMException exercises the same
+    // `mapTransportError` path while removing the real-timer race that flaked
+    // under saturated CI runners (issue #120).
     const driver = {
       name: "slow",
-      request: (req: Request) =>
-        new Promise<Response>((_resolve, reject) => {
-          req.signal?.addEventListener("abort", () => reject(req.signal!.reason), { once: true })
-        }),
+      request: (_req: Request) =>
+        Promise.reject(new DOMException("The operation timed out.", "TimeoutError")),
     }
 
     const m = createMisina({ driver, retry: 0, timeout: 25 })
@@ -86,7 +90,7 @@ describe("audit pass 1 — TimeoutError carries the configured timeout (Bug 18)"
         throw err
       }
     }
-  }, 3000)
+  })
 })
 
 describe("audit pass 1 — HTTPError.data is parsed during retry (Bug 16)", () => {


### PR DESCRIPTION
## Summary

Fixes the long-standing flake in `test/audit-fixes.test.ts > 'TimeoutError carries the configured timeout' > 'error.timeout reflects the option, not 0'` (issue #120, observed across cycles 5/6/7/8).

## Root cause

The test wired a driver whose `request` returned a Promise that only rejected once `req.signal` aborted. The signal aborted via the misina-built `AbortSignal.timeout(25)`. On a saturated runner (full suite, threads pool, ~118 parallel test files) the 25 ms native timer can drift well past the inner test's vitest budget, plus the per-attempt overhead of waiting for the abort listener to fire and propagate. Locally the test took 27-29 ms — only ~3 ms of headroom over the 25 ms timer, so any scheduling jitter on CI under load tipped it past whatever inner deadline Vitest was using and produced the intermittent failure.

## Fix approach

The contract under test is purely the *shape* of the resulting `TimeoutError` (`err.timeout === 25`, `err.message` includes `"25ms"`) — not the wall-clock behavior of `AbortSignal.timeout`. The `mapTransportError` path in `src/misina.ts` triggers the configured-timeout branch whenever `cause.name === "TimeoutError"`, so the test now drives that path synchronously by having the driver reject with `new DOMException("...", "TimeoutError")`. No real timer fires, no wall-clock dependency, runtime drops from ~28 ms to ~2 ms.

Rationale vs alternatives:
- `vi.useFakeTimers()` — would not help here. `AbortSignal.timeout` is implemented by the host (Node), not via the timer functions Vitest replaces, so faking timers does not advance it.
- Bumping to `timeout: 100` + 5 s test budget — works but keeps the wall-clock dependency and inflates test duration without reason.
- `it.retry(2)` — masks the symptom, explicitly discouraged by the issue.

## Verification

- Ran `pnpm exec vitest run --pool=threads --maxConcurrency=20` 5 consecutive times: 5/5 clean, 932/932 tests passing each run.
- Ran the full `pnpm test` (lint + typecheck + vitest): green.
- The test still hits the same `mapTransportError` branch and asserts the same observable contract.

Closes #120.