### PR TITLE
fix(examples): point 06-sse at a live public SSE endpoint

### DIFF
--- a/examples/06-sse.ts
+++ b/examples/06-sse.ts
@@ -2,23 +2,26 @@
  * Consume a Server-Sent Events stream.
  * Run: pnpm dlx tsx examples/06-sse.ts
  *
- * httpbin doesn't host an SSE endpoint, so this uses sse.dev which echoes
- * a message every 2s. Press Ctrl+C to stop.
+ * sse.dev no longer resolves, so this uses DexPaprika's public stream:
+ * free, no API key, emits a named `token_price` event with the live WETH
+ * price every few seconds (plus `ping` keepalives between price ticks).
+ * Docs: https://docs.dexpaprika.com/streaming
  */
 import { createMisina } from "../src/index.ts"
 import { sseStream } from "../src/stream/index.ts"
 
 const api = createMisina({ retry: 0, throwHttpErrors: false })
 
-const res = await api.get("https://sse.dev/test", { responseType: "stream" })
-
-const controller = new AbortController()
-setTimeout(() => controller.abort(), 8000) // give up after 8s
+const weth = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+const res = await api.get(
+  `https://streaming.dexpaprika.com/sse/prices?method=token_price&chain=ethereum&address=${weth}`,
+  { responseType: "stream", signal: AbortSignal.timeout(30_000) },
+)
 
 let i = 0
 try {
   for await (const event of sseStream(res.raw)) {
-    if (controller.signal.aborted) break
+    if (event.event !== "token_price") continue // skip keepalives
     console.log(`#${++i}`, event.event, event.data.slice(0, 80))
     if (i >= 3) break
   }


### PR DESCRIPTION
The example's own comment says "httpbin doesn't host an SSE endpoint, so this uses sse.dev which echoes a message every 2s", but sse.dev no longer resolves (NXDOMAIN), so the example dies on the initial GET. This swaps in DexPaprika's free, keyless price stream and filters on the named `token_price` event, which also exercises the `SseEvent.event` field properly; the manual AbortController became `AbortSignal.timeout` per the runtime-baseline rule in AGENTS.md. Verified live with `pnpm dlx tsx examples/06-sse.ts` (plus `pnpm lint`, `pnpm typecheck`, and the full vitest suite, 932 passing), first event off the wire:

```
event: token_price
data: {"address":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2","chain":"ethereum","price":"1840.545532633754","timestamp":1784283722,...}
```

Disclosure: I do DevRel for DexPaprika. The endpoint is public, no key or signup needed.
